### PR TITLE
Change the way we calculate uuids.

### DIFF
--- a/morango/utils/uuids.py
+++ b/morango/utils/uuids.py
@@ -1,8 +1,13 @@
+import hashlib
 import uuid
 
 from django.db import models
 
 from . import NAMESPACE_MORANGO
+
+
+def sha2_uuid(*args):
+    return hashlib.sha256("::".join(args)).hexdigest()[:32]
 
 
 class UUIDField(models.CharField):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-django==1.9
+django==1.9.7
 django-mptt>=0.8.0
 rsa==3.4.2
 M2Crypto==0.26.0

--- a/tests/testapp/facility_profile/models.py
+++ b/tests/testapp/facility_profile/models.py
@@ -32,9 +32,11 @@ class Facility(MorangoMPTTModel, FacilityDataSyncableModel):
     now_date = models.DateTimeField(default=timezone.now)
     parent = TreeForeignKey('self', null=True, blank=True, related_name='children', db_index=True)
 
-    def get_partition(self, *args, **kwargs):
-        return {}
+    def calculate_source_id(self, *args, **kwargs):
+        return ''
 
+    def calculate_partition(self, *args, **kwargs):
+        return ''
 
 class MyUser(AbstractBaseUser, FacilityDataSyncableModel):
     # Morango syncing settings
@@ -47,8 +49,11 @@ class MyUser(AbstractBaseUser, FacilityDataSyncableModel):
 
     objects = BaseQuerySet.as_manager()
 
-    def get_partition(self, *args, **kwargs):
-        return {}
+    def calculate_source_id(self, *args, **kwargs):
+        return ''
+
+    def calculate_partition(self, *args, **kwargs):
+        return ''
 
 
 class Log(FacilityDataSyncableModel):
@@ -59,9 +64,11 @@ class Log(FacilityDataSyncableModel):
     user = models.ForeignKey(MyUser)
     content_id = UUIDField(db_index=True, default=uuid.uuid4)
 
-    def get_partition(self, *args, **kwargs):
-        pass
+    def calculate_source_id(self, *args, **kwargs):
+        return ''
 
+    def calculate_partition(self, *args, **kwargs):
+        return ''
 
 class ProxyParent(MorangoMPTTModel):
 
@@ -75,9 +82,11 @@ class ProxyParent(MorangoMPTTModel):
         if self._KIND:
             self.kind = self._KIND
 
-    def get_partition(self, *args, **kwargs):
-        return {}
+    def calculate_source_id(self, *args, **kwargs):
+        return ''
 
+    def calculate_partition(self, *args, **kwargs):
+        return ''
 
 class ProxyManager(models.Manager):
     pass
@@ -93,5 +102,8 @@ class ProxyModel(ProxyParent):
     class Meta:
         proxy = True
 
-    def get_partition(self, *args, **kwargs):
-        return {}
+    def calculate_source_id(self, *args, **kwargs):
+        return ''
+
+    def calculate_partition(self, *args, **kwargs):
+        return ''


### PR DESCRIPTION
## Summary

We now calculate uuids based on the partition values of the model, as well as the source id (which will be unique fields on the model or a random uuid). 

NOTE:
Tests will break, but we will fix at a later time. 