### PR TITLE
Correctly inherit from SyncableQuerySet.

### DIFF
--- a/morango/manager.py
+++ b/morango/manager.py
@@ -3,7 +3,5 @@ from django.db import models
 from .query import SyncableModelQuerySet
 
 
-class SyncableModelManager(models.Manager):
-
-    def get_queryset(self):
-        return SyncableModelQuerySet(self.model, using=self._db)
+class SyncableModelManager(models.Manager.from_queryset(SyncableModelQuerySet)):
+    pass


### PR DESCRIPTION
## Summary

This is how we are supposed to inherit so methods get copied on the queryset class correctly.