### PR TITLE
Stop using proxied_children in django internal api.

### DIFF
--- a/morango/utils/register_models.py
+++ b/morango/utils/register_models.py
@@ -101,7 +101,8 @@ def add_syncable_models():
     for base_model, proxy_list in iteritems(proxy_dict):
         for proxy_model in proxy_list:
             _insert_model_into_profile_dict(proxy_model, profile)
-        _profile_models[profile].remove(base_model)
+        if base_model in _profile_models:
+            _profile_models[profile].remove(base_model)
 
     # for each profile, create a dict mapping from morango model names to model class
     for profile, model_list in iteritems(_profile_models):

--- a/morango/utils/register_models.py
+++ b/morango/utils/register_models.py
@@ -26,6 +26,10 @@ def _insert_model_into_profile_dict(model, profile):
     # Get the dependencies of the new model
     foreign_key_classes = _get_foreign_key_classes(model)
 
+    # add any more specified dependencies
+    if hasattr(model, '_morango_model_dependencies'):
+        foreign_key_classes = foreign_key_classes | set(model._morango_model_dependencies)
+
     # Find all the existing models that this new model refers to.
     class_indices = [_profile_models[profile].index(cls) for cls in foreign_key_classes if cls in _profile_models[profile]]
 
@@ -49,10 +53,9 @@ def add_syncable_models():
     from morango.query import SyncableModelQuerySet
 
     model_list = []
-    proxy_dict = {}
     for model_class in django.apps.apps.get_models():
         # several validation checks to assert models will be syncing correctly
-        if issubclass(model_class, SyncableModel) and not model_class._meta.proxy:
+        if issubclass(model_class, SyncableModel):
             name = model_class.__name__
             try:
                 from mptt import models
@@ -83,26 +86,9 @@ def add_syncable_models():
             profile = model_class.morango_profile
             _profile_models[profile] = _profile_models.get(profile, [])
 
-            _insert_model_into_profile_dict(model_class, profile)
-
-        # we keep track of all proxy models in relation to their parent class
-        elif model_class._meta.proxy:
-            base_proxy_model = model_class._meta.proxy_for_model
-            proxy_dict[base_proxy_model] = proxy_dict.get(base_proxy_model, [])
-            if issubclass(base_proxy_model, SyncableModel):
-                if hasattr(model_class, '_morango_proxy_order'):
-                    proxy_dict[base_proxy_model].append(model_class)
-
-    # sort by _morango_proxy_order
-    for proxy in proxy_dict:
-        proxy_dict[proxy] = sorted(proxy_dict[proxy], key=lambda p: p._morango_proxy_order, reverse=True)
-
-    # add proxy models based on order, and remove parent class
-    for base_model, proxy_list in iteritems(proxy_dict):
-        for proxy_model in proxy_list:
-            _insert_model_into_profile_dict(proxy_model, profile)
-        if base_model in _profile_models:
-            _profile_models[profile].remove(base_model)
+            # don't sync models where morango_model_name is None
+            if model_class.morango_model_name is not None:
+                _insert_model_into_profile_dict(model_class, profile)
 
     # for each profile, create a dict mapping from morango model names to model class
     for profile, model_list in iteritems(_profile_models):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-django>=1.9.7,<1.10
+django>=1.9.7
 django-mptt>=0.8.0
 rsa>=3.4.2
 djangorestframework>=3.3.3


### PR DESCRIPTION
## Summary

`Proxied_children` is an internal django field that was used but later removed. We still use the internal api for registering proxy models, but the methods are consistent across latest versions of django. 