### PR TITLE
Add upper bounds to requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
-django>=1.9.7
-django-mptt>=0.8.0
-rsa>=3.4.2
+django>=1.9.7,<1.12
+django-mptt>=0.8.0,<0.9
+rsa>=3.4.2,<3.5
 djangorestframework>=3.3.3,<3.7
-django-ipware>=1.1.6
+django-ipware>=1.1.6,<1.2
 future==0.16.0
 requests


### PR DESCRIPTION
It's dangerous down the road to have no upper bounds. Of course it's hard to tell the future, but the best bet is to trust the semantic versioning competence of the upstream :)

I'm leaving out requests, because their version schema was to hard to crack for me :)