### PR TITLE
Use twine for releasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,10 @@ docs: ## generate Sphinx HTML documentation, including API docs
 servedocs: docs ## compile the docs watching for changes
 	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
 
-release: clean ## package and upload a release
-	python setup.py sdist upload
-	python setup.py bdist_wheel upload
+release:
+	ls -l dist/
+	read "\nDo you want to upload everything in dist/*?\n\n CTRL+C to exit."
+	twine upload -s dist/*
 
 dist: clean ## builds source and wheel package
 	python setup.py sdist


### PR DESCRIPTION
## Summary

I used the same procedure from Kolibri, whereby `release` doesn't depend on `dist` -- it's nice because then you can run `dist`, check that everything is working (in some local `pip install dist/morango-x.y.whl`) and then run `make release`