### PR TITLE
Expand test matrix w/ different django+cryptography releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,39 @@
-# Config file for automatic testing at travis-ci.org
-# This file will be regenerated if you run travis_pypi_setup.py
+dist: trusty
 
 language: python
 
-sudo: false
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
+env:
+  - LINT="yes"
+  - DJANGO="1.9"
+  - DJANGO="1.10"
+  - DJANGO="1.11"
 
 matrix:
-  include:
-    - python: 2.7
-      env:
-        - TOX_ENV=py2.7
-    - python: 2.7
-      env:
-        - TOX_ENV=docs
-    - python: 3.4
-      env:
-        - TOX_ENV=py3.4
-    - python: 3.5
-      env:
-        - TOX_ENV=py3.5
-
+  exclude:
+  - python: "3.4"
+    env: LINT="yes"
+  - python: "3.5"
+    env: LINT="yes"
+  - python: "3.6"
+    env: LINT="yes"
+  - python: "3.6"
+    env: DJANGO="1.9"
+  - python: "3.6"
+    env: DJANGO="1.10"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 before_install:
-  - pip install tox
-  - pip install codecov
+  - pip install tox tox-travis codecov
 
 # command to run tests, e.g. python setup.py test
 script:
-  - tox -e $TOX_ENV
+  - tox
 
 after_success:
   - codecov
-
-notifications:
-  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,11 @@ python:
   - "3.6"
 
 env:
-  - LINT="yes"
-  - DJANGO="1.9"
-  - DJANGO="1.10"
-  - DJANGO="1.11"
+# Removed because linting PR coming up separately
+#  - LINT="yes"
+  - DJANGO="1.9" CRYPTOGRAPHY="2.0"
+  - DJANGO="1.10" CRYPTOGRAPHY="2.0"
+  - DJANGO="1.11" CRYPTOGRAPHY="2.0"
 
 matrix:
   exclude:
@@ -23,9 +24,9 @@ matrix:
   - python: "3.6"
     env: LINT="yes"
   - python: "3.6"
-    env: DJANGO="1.9"
+    env: DJANGO="1.9" CRYPTOGRAPHY="2.0"
   - python: "3.6"
-    env: DJANGO="1.10"
+    env: DJANGO="1.10" CRYPTOGRAPHY="2.0"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 before_install:

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "morango.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.testapp.settings")
 
     from django.core.management import execute_from_command_line
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,3 @@
--r base.txt
 # These are for testing
 fake-factory
 factory-boy

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,4 +6,3 @@ mock
 pytest
 pytest-cov
 pytest-django
-cryptography

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,3 @@
-[bumpversion]
-current_version = 0.1.0
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:morango/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [bdist_wheel]
 universal = 1
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,11 @@ DJANGO =
   1.9: django19
   1.10: django110
   1.11: django111
+CRYPTOGRAPHY =
+  1.2: cryptography12
+  2.0: cryptography20
+LINT =
+  yes: lint
 
 [testenv]
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,9 @@ DJANGO =
 
 [testenv]
 
+setenv =
+  PYTHONPATH = {toxinidir}:{toxinidir}/tests/testapp
+
 basepython =
   py27: python2.7
   py34: python3.4
@@ -51,4 +54,4 @@ deps =
   cryptography20: cryptography==2.0.3
 
 commands =
-  py.test --cov=morango --color=no {posargs}
+  py.test --cov=morango {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36}-django{19,110,111},lint,docs
+envlist = {py27,py34,py35,py36}-django{19,110,111}-cryptography{12,20},lint,docs
 
 [testenv:lint]
 deps =
@@ -47,6 +47,8 @@ deps =
   django19: Django>=1.9,<1.10
   django110: Django>=1.10,<1.11
   django111: Django>=1.11,<1.12
+  cryptography12: cryptography==1.2.3
+  cryptography20: cryptography==2.0.3
 
 commands =
   py.test --cov=morango --color=no {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,33 +1,52 @@
 [tox]
-envlist = py2.7, py3.4, py3.5, lint, docs
+envlist = {py27,py34,py35,py36}-django{19,110,111},lint,docs
 
 [testenv:lint]
 deps =
-    flake8
+  flake8
 commands =
-    flake8 morango
+  flake8 morango
 
 [testenv:docs]
+
 changedir = docs
 deps = sphinx
 commands =
-    sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
+  sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
+
+[travis]
+python =
+  2.7: py27,lint
+  3.4: py34
+  3.5: py35
+  3.6: py36
+
+[travis:env]
+DJANGO =
+  1.9: django19
+  1.10: django110
+  1.11: django111
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/tests/testapp
-basepython =
-    py2.7: python2.7
-    py3.4: python3.4
-    py3.5: python3.5
-    docs: python2.7
-    lint: python2.7
-deps =
-    -r{toxinidir}/requirements/test.txt
-commands =
-    py.test --cov=morango --color=no {posargs}
 
-; If you want to make tox run the tests with the same versions, create a
-; requirements.txt with the pinned versions and uncomment the following lines:
-; deps =
-;     -r{toxinidir}/requirements.txt
+basepython =
+  py27: python2.7
+  py34: python3.4
+  py35: python3.5
+  py36: python3.6
+  docs: python2.7
+  lint: python2.7
+
+deps =
+  -r{toxinidir}/requirements/test.txt
+  django-mptt>=0.8.0
+  rsa>=3.4.2
+  djangorestframework>=3.3.3
+  django-ipware>=1.1.6
+  future==0.16.0
+  django19: Django>=1.9,<1.10
+  django110: Django>=1.10,<1.11
+  django111: Django>=1.11,<1.12
+
+commands =
+  py.test --cov=morango --color=no {posargs}


### PR DESCRIPTION
## Summary

Changes tox to use current Python environment and sets Travis to test with Python 2.7, 3.4, 3.5, 3.6