### PR TITLE
Explicitly set current flag to True after retrieval/creation.

### DIFF
--- a/morango/models.py
+++ b/morango/models.py
@@ -92,9 +92,10 @@ class InstanceIDModel(UUIDModelMixin):
 
         # do within transaction so we only ever have 1 current instance ID
         with transaction.atomic():
+            InstanceIDModel.objects.filter(current=True).update(current=False)
             obj, created = InstanceIDModel.objects.get_or_create(**kwargs)
-            if created:
-                InstanceIDModel.objects.exclude(id=obj.id).update(current=False)
+            obj.current = True
+            obj.save()
 
         return obj, created
 

--- a/tests/testapp/tests/test_uuid_utilities.py
+++ b/tests/testapp/tests/test_uuid_utilities.py
@@ -62,6 +62,20 @@ class InstanceIDModelTestCase(TestCase):
             InstanceIDModel.get_or_create_current_instance()
         self.assertEqual(len(InstanceIDModel.objects.filter(current=True)), 1)
 
+    def test_same_node_id(self):
+        with mock.patch('uuid.getnode', return_value=67002173923623):  # fake (random) address
+            (IDModel, _) = InstanceIDModel.get_or_create_current_instance()
+            ident = IDModel.id
+
+        with mock.patch('uuid.getnode', return_value=69002173923623):  # fake (random) address
+            (IDModel, _) = InstanceIDModel.get_or_create_current_instance()
+
+        with mock.patch('uuid.getnode', return_value=67002173923623):  # fake (random) address
+            (IDModel, _) = InstanceIDModel.get_or_create_current_instance()
+
+        self.assertFalse(InstanceIDModel.objects.exclude(id=ident).filter(current=True).exists())
+        self.assertTrue(InstanceIDModel.objects.get(id=ident).current)
+
 
 class DatabaseIDModelTestCase(TestCase):
 


### PR DESCRIPTION
## Summary

Fix that actually sets previously created Instance IDs current flag to true.

## TODO

- [x] Have tests been written for the new code?


## Issues addressed

Instance IDs that were created and then retrieved from swapping out wifi dongles did not reset the current flag to True. So the incorrect instance ID model would be set to true.

