### PR TITLE
Update store deleted flag if object is recreated after being deleted.

### DIFF
--- a/morango/utils/sync_utils.py
+++ b/morango/utils/sync_utils.py
@@ -79,9 +79,10 @@ def _serialize_into_store(profile, filter=None):
                     # update last saved bys for this store model
                     store_model.last_saved_instance = current_id.id
                     store_model.last_saved_counter = current_id.counter
+                    store_model.deleted = False
 
                     # update fields for this store model
-                    store_model.save(update_fields=['serialized', 'last_saved_instance', 'last_saved_counter', 'conflicting_serialized_data'])
+                    store_model.save(update_fields=['serialized', 'last_saved_instance', 'last_saved_counter', 'conflicting_serialized_data', 'deleted'])
 
                 except Store.DoesNotExist:
                     kwargs = {

--- a/tests/testapp/tests/test_controller_methods.py
+++ b/tests/testapp/tests/test_controller_methods.py
@@ -194,6 +194,18 @@ class SerializeIntoStoreTestCase(TestCase):
         self.mc.serialize_into_store()
         self.assertEqual(Store.objects.get(id=log.id)._self_ref_fk, '')
 
+    def test_previously_deleted_store_flag_resets(self):
+        # create and delete object
+        user = MyUser.objects.create(username='user')
+        self.mc.serialize_into_store()
+        MyUser.objects.all().delete()
+        self.mc.serialize_into_store()
+        self.assertTrue(Store.objects.get(id=user.id).deleted)
+        # recreate object with same id
+        user = MyUser.objects.create(username='user')
+        # ensure deleted flag is updated after recreation
+        self.mc.serialize_into_store()
+        self.assertFalse(Store.objects.get(id=user.id).deleted)
 
 class RecordMaxCounterUpdatesDuringSerialization(TestCase):
 


### PR DESCRIPTION
## Summary

Resets deleted flag on the store records.

## TODO

- [x] Have tests been written for the new code?

## Issues addressed

A model that was deleted/synced would set its store's deleted flag to `True`. If the model was created again (as long as it has the same `id`), upon serialization the deleted flag would not be set to `False`. This had the problem of syncing with another device, that the model would not be deserialized because its store record says its deleted.
