### PR TITLE
Db backend routing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 dist: trusty
 
+sudo: required
+
 language: python
+
+services:
+  - postgresql
 
 python:
   - "2.7"
@@ -19,6 +24,9 @@ env:
   - DJANGO="1.11" CRYPTOGRAPHY="2.0"
 
 matrix:
+  include:
+  - python: "2.7"
+    env: POSTGRES="yes"
   exclude:
   - python: "2.7"
     env: DJANGO="1.10" CRYPTOGRAPHY="1.2"
@@ -45,6 +53,9 @@ matrix:
 before_install:
   - pip install tox tox-travis codecov
 
+before_script:
+  - psql -c 'create database travis_ci_test;' -U postgres
+
 # command to run tests, e.g. python setup.py test
 script:
   - tox
@@ -53,3 +64,5 @@ after_success:
   - coverage combine
   - codecov
 
+notifications:
+    email: False

--- a/morango/models.py
+++ b/morango/models.py
@@ -10,7 +10,8 @@ import uuid
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import connection, models, transaction
-from django.db.models import F
+from django.db.models import F, Func, TextField, Value
+from django.db.models.functions import Cast
 from django.utils import timezone
 from django.utils.six import iteritems
 from morango.utils.register_models import _profile_models
@@ -239,6 +240,21 @@ class AbstractStore(models.Model):
         abstract = True
 
 
+class StoreQueryset(models.QuerySet):
+
+    def char_ids_list(self):
+        return (self.annotate(id_cast=Cast('id', TextField())) \
+               # remove dashes from char uuid
+               .annotate(fixed_id=Func(F('id_cast'), Value('-'), Value(''), function='replace',)) \
+               # return as list
+               .values_list("fixed_id", flat=True))
+
+
+class StoreManager(models.Manager):
+    def get_queryset(self):
+        return StoreQueryset(self.model, using=self._db)
+
+
 class Store(AbstractStore):
     """
     ``Store`` is the concrete model where serialized data is persisted, along with
@@ -248,6 +264,8 @@ class Store(AbstractStore):
     id = UUIDField(primary_key=True)
     # used to know which store records need to be deserialized into the app layer models
     dirty_bit = models.BooleanField(default=False)
+
+    objects = StoreManager()
 
     def _deserialize_store_model(self):
         klass_model = _profile_models[self.profile][self.model_name]

--- a/morango/utils/backends/base.py
+++ b/morango/utils/backends/base.py
@@ -1,0 +1,122 @@
+from morango.models import Buffer, RecordMaxCounterBuffer, Store, RecordMaxCounter
+
+
+class BaseSQLWrapper(object):
+
+    def _dequeuing_delete_rmcb_records(self, cursor, transfersession_id):
+        # delete all RMCBs which are a reverse FF (store version newer than buffer version)
+        delete_rmcb_records = """DELETE FROM {rmcb}
+                                 WHERE model_uuid IN
+                                 (SELECT rmcb.model_uuid FROM {store} as store, {buffer} as buffer, {rmc} as rmc, {rmcb} as rmcb
+                                 /*Scope to a single record*/
+                                 WHERE store.id = buffer.model_uuid
+                                 AND  store.id = rmc.store_model_id
+                                 AND  store.id = rmcb.model_uuid
+                                 /*Checks whether LSB of buffer or less is in RMC of store*/
+                                 AND buffer.last_saved_instance = rmc.instance_id
+                                 AND buffer.last_saved_counter <= rmc.counter
+                                 AND rmcb.transfer_session_id = '{transfer_session_id}'
+                                 AND buffer.transfer_session_id = '{transfer_session_id}')
+                                  """.format(buffer=Buffer._meta.db_table,
+                                             store=Store._meta.db_table,
+                                             rmc=RecordMaxCounter._meta.db_table,
+                                             rmcb=RecordMaxCounterBuffer._meta.db_table,
+                                             transfer_session_id=transfersession_id)
+
+        cursor.execute(delete_rmcb_records)
+
+    def _dequeuing_delete_buffered_records(self, cursor, transfersession_id):
+        # delete all buffer records which are a reverse FF (store version newer than buffer version)
+        delete_buffered_records = """DELETE FROM {buffer}
+                                     WHERE model_uuid in
+                                     (SELECT buffer.model_uuid FROM {store} as store, {buffer} as buffer, {rmc} as rmc
+                                     /*Scope to a single record*/
+                                     WHERE store.id = buffer.model_uuid
+                                     AND rmc.store_model_id = buffer.model_uuid
+                                     /*Checks whether LSB of buffer or less is in RMC of store*/
+                                     AND buffer.last_saved_instance = rmc.instance_id
+                                     AND buffer.last_saved_counter <= rmc.counter
+                                     AND buffer.transfer_session_id = '{transfer_session_id}')
+                                  """.format(buffer=Buffer._meta.db_table,
+                                             store=Store._meta.db_table,
+                                             rmc=RecordMaxCounter._meta.db_table,
+                                             rmcb=RecordMaxCounterBuffer._meta.db_table,
+                                             transfer_session_id=transfersession_id)
+        cursor.execute(delete_buffered_records)
+
+    def _dequeuing_merge_conflict_rmcb(self, cursor, transfersession_id):
+        raise NotImplemented("Subclass must implement this method.")
+
+    def _dequeuing_merge_conflict_buffer(self, cursor, current_id, transfersession_id):
+        raise NotImplemented("Subclass must implement this method.")
+
+    def _dequeuing_update_rmcs_last_saved_by(self, cursor, current_id, transfersession_id):
+        raise NotImplemented("Subclass must implement this method.")
+
+    def _dequeuing_delete_mc_buffer(self, cursor, transfersession_id):
+        # delete records with merge conflicts from buffer
+        delete_mc_buffer = """DELETE FROM {buffer}
+                                    WHERE EXISTS
+                                    (SELECT 1 FROM {store} AS store, {buffer} AS buffer
+                                    /*Scope to a single record.*/
+                                    WHERE store.id = {buffer}.model_uuid
+                                    AND {buffer}.transfer_session_id = '{transfer_session_id}'
+                                    /*Exclude fast-forwards*/
+                                    AND NOT EXISTS (SELECT 1 FROM {rmcb} AS rmcb WHERE store.id = rmcb.model_uuid
+                                                                                  AND store.last_saved_instance = rmcb.instance_id
+                                                                                  AND store.last_saved_counter <= rmcb.counter
+                                                                                  AND rmcb.transfer_session_id = '{transfer_session_id}'))
+                               """.format(buffer=Buffer._meta.db_table,
+                                          store=Store._meta.db_table,
+                                          rmc=RecordMaxCounter._meta.db_table,
+                                          rmcb=RecordMaxCounterBuffer._meta.db_table,
+                                          transfer_session_id=transfersession_id)
+        cursor.execute(delete_mc_buffer)
+
+    def _dequeuing_delete_mc_rmcb(self, cursor, transfersession_id):
+        # delete rmcb records with merge conflicts
+        delete_mc_rmc = """DELETE FROM {rmcb}
+                                    WHERE EXISTS
+                                    (SELECT 1 FROM {store} AS store, {rmc} AS rmc
+                                    /*Scope to a single record.*/
+                                    WHERE store.id = {rmcb}.model_uuid
+                                    AND store.id = rmc.store_model_id
+                                    /*Where buffer rmc is greater than store rmc*/
+                                    AND {rmcb}.instance_id = rmc.instance_id
+                                    AND {rmcb}.transfer_session_id = '{transfer_session_id}'
+                                    /*Exclude fast fast-forwards*/
+                                    AND NOT EXISTS (SELECT 1 FROM {rmcb} AS rmcb2 WHERE store.id = rmcb2.model_uuid
+                                                                                  AND store.last_saved_instance = rmcb2.instance_id
+                                                                                  AND store.last_saved_counter <= rmcb2.counter
+                                                                                  AND rmcb2.transfer_session_id = '{transfer_session_id}'))
+                               """.format(buffer=Buffer._meta.db_table,
+                                          store=Store._meta.db_table,
+                                          rmc=RecordMaxCounter._meta.db_table,
+                                          rmcb=RecordMaxCounterBuffer._meta.db_table,
+                                          transfer_session_id=transfersession_id)
+        cursor.execute(delete_mc_rmc)
+
+    def _dequeuing_insert_remaining_buffer(self, cursor, transfersession_id):
+        raise NotImplemented("Subclass must implement this method.")
+
+    def _dequeuing_insert_remaining_rmcb(self, cursor, transfersession_id):
+        raise NotImplemented("Subclass must implement this method.")
+
+    def _dequeuing_delete_remaining_rmcb(self, cursor, transfersession_id):
+        # delete the remaining rmcb for this transfer session
+        delete_remaining_rmcb = """
+                                DELETE FROM {rmcb}
+                                WHERE {rmcb}.transfer_session_id = '{transfer_session_id}'
+                                """.format(rmcb=RecordMaxCounterBuffer._meta.db_table,
+                                           transfer_session_id=transfersession_id)
+
+        cursor.execute(delete_remaining_rmcb)
+
+    def _dequeuing_delete_remaining_buffer(self, cursor, transfersession_id):
+        # delete the remaining buffer for this transfer session
+        delete_remaining_buffer = """
+                                  DELETE FROM {buffer}
+                                  WHERE {buffer}.transfer_session_id = '{transfer_session_id}'
+                                  """.format(buffer=Buffer._meta.db_table,
+                                             transfer_session_id=transfersession_id)
+        cursor.execute(delete_remaining_buffer)

--- a/morango/utils/backends/postgres.py
+++ b/morango/utils/backends/postgres.py
@@ -1,4 +1,4 @@
-from base import BaseSQLWrapper
+from morango.utils.backends.base import BaseSQLWrapper
 from morango.models import (Buffer, RecordMaxCounter, RecordMaxCounterBuffer,
                             Store)
 

--- a/morango/utils/backends/postgres.py
+++ b/morango/utils/backends/postgres.py
@@ -1,0 +1,159 @@
+from base import BaseSQLWrapper
+from morango.models import (Buffer, RecordMaxCounter, RecordMaxCounterBuffer,
+                            Store)
+
+
+class SQLWrapper(BaseSQLWrapper):
+    backend = 'postgresql'
+
+    def _dequeuing_merge_conflict_rmcb(self, cursor, transfersession_id):
+        # transfer record max counters for records with merge conflicts + perform max
+        merge_conflict_rmc = """UPDATE {rmc} as rmc SET (counter)
+                                    = (rmcb.counter)
+                                    FROM {rmcb} AS rmcb, {store} AS store, {buffer} AS buffer
+                                    /*Scope to a single record.*/
+                                    WHERE store.id = rmcb.model_uuid
+                                    AND store.id = rmc.store_model_id
+                                    AND store.id = buffer.model_uuid
+                                    /*Where buffer rmc is greater than store rmc*/
+                                    AND rmcb.instance_id = rmc.instance_id
+                                    AND rmcb.counter > rmc.counter
+                                    AND rmcb.transfer_session_id = '{transfer_session_id}'
+                                    /*Exclude fast-forwards*/
+                                    AND NOT EXISTS (SELECT 1 FROM {rmcb} AS rmcb2 WHERE store.id = rmcb2.model_uuid
+                                                                                  AND store.last_saved_instance = rmcb2.instance_id
+                                                                                  AND store.last_saved_counter <= rmcb2.counter
+                                                                                  AND rmcb2.transfer_session_id = '{transfer_session_id}')
+                               """.format(buffer=Buffer._meta.db_table,
+                                          store=Store._meta.db_table,
+                                          rmc=RecordMaxCounter._meta.db_table,
+                                          rmcb=RecordMaxCounterBuffer._meta.db_table,
+                                          transfer_session_id=transfersession_id)
+
+        cursor.execute(merge_conflict_rmc)
+
+    def _dequeuing_merge_conflict_buffer(self, cursor, current_id, transfersession_id):
+        # transfer buffer serialized into conflicting store
+        merge_conflict_store = """UPDATE {store} as store SET (serialized, deleted, last_saved_instance, last_saved_counter, model_name,
+                                                        profile, partition, source_id, conflicting_serialized_data, dirty_bit, _self_ref_fk)
+                                            = (store.serialized, store.deleted OR buffer.deleted, '{current_instance_id}',
+                                                   {current_instance_counter}, store.model_name, store.profile, store.partition, store.source_id,
+                                                   buffer.serialized || '\n' || store.conflicting_serialized_data, TRUE, store._self_ref_fk)
+                                            /*Scope to a single record.*/
+                                            FROM {buffer} AS buffer
+                                            WHERE store.id = buffer.model_uuid
+                                            AND buffer.transfer_session_id = '{transfer_session_id}'
+                                            /*Exclude fast-forwards*/
+                                            AND NOT EXISTS (SELECT 1 FROM {rmcb} AS rmcb2 WHERE store.id = rmcb2.model_uuid
+                                                                                          AND store.last_saved_instance = rmcb2.instance_id
+                                                                                          AND store.last_saved_counter <= rmcb2.counter
+                                                                                          AND rmcb2.transfer_session_id = '{transfer_session_id}')
+                                      """.format(buffer=Buffer._meta.db_table,
+                                                 rmcb=RecordMaxCounterBuffer._meta.db_table,
+                                                 store=Store._meta.db_table,
+                                                 rmc=RecordMaxCounter._meta.db_table,
+                                                 transfer_session_id=transfersession_id,
+                                                 current_instance_id=current_id.id,
+                                                 current_instance_counter=current_id.counter)
+
+        cursor.execute(merge_conflict_store)
+
+    def _dequeuing_update_rmcs_last_saved_by(self, cursor, current_id, transfersession_id):
+        # update or create rmc for merge conflicts with local instance id
+        merge_conflict_store = """
+                WITH new_values as
+            (
+                SELECT '{current_instance_id}'::uuid curr_id, {current_instance_counter} curr_counter, store.id
+                FROM {store} as store, {buffer} as buffer
+                /*Scope to a single record.*/
+                WHERE store.id = buffer.model_uuid
+                AND buffer.transfer_session_id = '{transfer_session_id}'
+                /*Exclude fast-forwards*/
+                AND NOT EXISTS (SELECT 1 FROM {rmcb} AS rmcb2 WHERE store.id = rmcb2.model_uuid
+                                                              AND store.last_saved_instance = rmcb2.instance_id
+                                                              AND store.last_saved_counter <= rmcb2.counter
+                                                              AND rmcb2.transfer_session_id = '{transfer_session_id}')
+            ),
+            updated as
+            (
+                UPDATE {rmc} rmc
+                SET counter = nv.curr_counter
+                FROM new_values nv
+                WHERE store_model_id = nv.id AND instance_id = nv.curr_id
+                returning rmc.*
+            )
+            INSERT INTO {rmc}(instance_id, counter, store_model_id)
+            SELECT '{current_instance_id}'::uuid, {current_instance_counter}, ut.id
+            FROM new_values ut
+            WHERE ut.id not in (SELECT store_model_id FROM updated)
+        """.format(buffer=Buffer._meta.db_table,
+                   rmcb=RecordMaxCounterBuffer._meta.db_table,
+                   store=Store._meta.db_table,
+                   rmc=RecordMaxCounter._meta.db_table,
+                   transfer_session_id=transfersession_id,
+                   current_instance_id=current_id.id,
+                   current_instance_counter=current_id.counter)
+
+        cursor.execute(merge_conflict_store)
+
+    def _dequeuing_insert_remaining_buffer(self, cursor, transfersession_id):
+        # insert remaining records into store
+        insert_remaining_buffer = """
+            WITH new_values as
+            (
+                SELECT buffer.model_uuid, buffer.serialized, buffer.deleted, buffer.last_saved_instance, buffer.last_saved_counter,
+                       buffer.model_name, buffer.profile, buffer.partition, buffer.source_id, buffer.conflicting_serialized_data, buffer._self_ref_fk
+                FROM {buffer} as buffer
+                WHERE buffer.transfer_session_id = '{transfer_session_id}'
+            ),
+            updated as
+            (
+                UPDATE {store} store SET (serialized, deleted, last_saved_instance, last_saved_counter,
+                                     model_name, profile, partition, source_id, conflicting_serialized_data, dirty_bit, _self_ref_fk)
+                                    = (nv.serialized, nv.deleted, nv.last_saved_instance, nv.last_saved_counter,
+                                       nv.model_name, nv.profile, nv.partition, nv.source_id, nv.conflicting_serialized_data, TRUE,
+                                       nv._self_ref_fk)
+                FROM new_values nv
+                WHERE nv.model_uuid = store.id
+                returning store.*
+            )
+            INSERT INTO {store}(id, serialized, deleted, last_saved_instance, last_saved_counter,
+                                model_name, profile, partition, source_id, conflicting_serialized_data, dirty_bit, _self_ref_fk)
+            SELECT ut.model_uuid, ut.serialized, ut.deleted, ut.last_saved_instance, ut.last_saved_counter,
+                       ut.model_name, ut.profile, ut.partition, ut.source_id, ut.conflicting_serialized_data, TRUE,
+                       ut._self_ref_fk
+            FROM new_values ut
+            WHERE ut.model_uuid not in (SELECT id FROM updated)
+        """.format(buffer=Buffer._meta.db_table,
+                   store=Store._meta.db_table,
+                   transfer_session_id=transfersession_id)
+
+        cursor.execute(insert_remaining_buffer)
+
+    def _dequeuing_insert_remaining_rmcb(self, cursor, transfersession_id):
+        # insert remaining records into rmc
+        insert_remaining_rmcb = """
+                WITH new_values as
+            (
+                SELECT rmcb.instance_id rmcb_instance_id, rmcb.counter, rmcb.model_uuid
+                FROM {rmcb} as rmcb
+                WHERE rmcb.transfer_session_id = '{transfer_session_id}'
+            ),
+            updated as
+            (
+                UPDATE {rmc} rmc
+                SET counter = nv.counter
+                FROM new_values nv
+                WHERE store_model_id = nv.model_uuid AND instance_id = nv.rmcb_instance_id
+                returning rmc.*
+            )
+            INSERT INTO {rmc}(instance_id, counter, store_model_id)
+            SELECT ut.rmcb_instance_id, ut.counter, ut.model_uuid
+            FROM new_values ut
+            WHERE (ut.model_uuid, ut.rmcb_instance_id)
+            not in (SELECT store_model_id, instance_id FROM updated)
+            """.format(rmc=RecordMaxCounter._meta.db_table,
+                       rmcb=RecordMaxCounterBuffer._meta.db_table,
+                       transfer_session_id=transfersession_id)
+
+        cursor.execute(insert_remaining_rmcb)

--- a/morango/utils/backends/sqlite.py
+++ b/morango/utils/backends/sqlite.py
@@ -1,0 +1,106 @@
+from base import BaseSQLWrapper
+from morango.models import (Buffer, RecordMaxCounter, RecordMaxCounterBuffer,
+                            Store)
+
+
+class SQLWrapper(BaseSQLWrapper):
+    backend = 'sqlite'
+
+    def _dequeuing_merge_conflict_rmcb(self, cursor, transfersession_id):
+        # transfer record max counters for records with merge conflicts + perform max
+        merge_conflict_rmc = """REPLACE INTO {rmc} (instance_id, counter, store_model_id)
+                                    SELECT rmcb.instance_id, rmcb.counter, rmcb.model_uuid
+                                    FROM {rmcb} AS rmcb, {store} AS store, {rmc} AS rmc, {buffer} AS buffer
+                                    /*Scope to a single record.*/
+                                    WHERE store.id = rmcb.model_uuid
+                                    AND store.id = rmc.store_model_id
+                                    AND store.id = buffer.model_uuid
+                                    /*Where buffer rmc is greater than store rmc*/
+                                    AND rmcb.instance_id = rmc.instance_id
+                                    AND rmcb.counter > rmc.counter
+                                    AND rmcb.transfer_session_id = '{transfer_session_id}'
+                                    /*Exclude fast-forwards*/
+                                    AND NOT EXISTS (SELECT 1 FROM {rmcb} AS rmcb2 WHERE store.id = rmcb2.model_uuid
+                                                                                  AND store.last_saved_instance = rmcb2.instance_id
+                                                                                  AND store.last_saved_counter <= rmcb2.counter
+                                                                                  AND rmcb2.transfer_session_id = '{transfer_session_id}')
+                               """.format(buffer=Buffer._meta.db_table,
+                                          store=Store._meta.db_table,
+                                          rmc=RecordMaxCounter._meta.db_table,
+                                          rmcb=RecordMaxCounterBuffer._meta.db_table,
+                                          transfer_session_id=transfersession_id)
+        cursor.execute(merge_conflict_rmc)
+
+    def _dequeuing_merge_conflict_buffer(self, cursor, current_id, transfersession_id):
+        # transfer buffer serialized into conflicting store
+        merge_conflict_store = """REPLACE INTO {store} (id, serialized, deleted, last_saved_instance, last_saved_counter, model_name,
+                                                        profile, partition, source_id, conflicting_serialized_data, dirty_bit, _self_ref_fk)
+                                            SELECT store.id, store.serialized, store.deleted OR buffer.deleted, '{current_instance_id}',
+                                                   {current_instance_counter}, store.model_name, store.profile, store.partition, store.source_id,
+                                                   buffer.serialized || '\n' || store.conflicting_serialized_data, 1, store._self_ref_fk
+                                            FROM {buffer} AS buffer, {store} AS store
+                                            /*Scope to a single record.*/
+                                            WHERE store.id = buffer.model_uuid
+                                            AND buffer.transfer_session_id = '{transfer_session_id}'
+                                            /*Exclude fast-forwards*/
+                                            AND NOT EXISTS (SELECT 1 FROM {rmcb} AS rmcb2 WHERE store.id = rmcb2.model_uuid
+                                                                                          AND store.last_saved_instance = rmcb2.instance_id
+                                                                                          AND store.last_saved_counter <= rmcb2.counter
+                                                                                          AND rmcb2.transfer_session_id = '{transfer_session_id}')
+                                      """.format(buffer=Buffer._meta.db_table,
+                                                 rmcb=RecordMaxCounterBuffer._meta.db_table,
+                                                 store=Store._meta.db_table,
+                                                 rmc=RecordMaxCounter._meta.db_table,
+                                                 transfer_session_id=transfersession_id,
+                                                 current_instance_id=current_id.id,
+                                                 current_instance_counter=current_id.counter)
+        cursor.execute(merge_conflict_store)
+
+    def _dequeuing_update_rmcs_last_saved_by(self, cursor, current_id, transfersession_id):
+        # update or create rmc for merge conflicts with local instance id
+        merge_conflict_store = """REPLACE INTO {rmc} (instance_id, counter, store_model_id)
+                                SELECT '{current_instance_id}', {current_instance_counter}, store.id
+                                FROM {store} as store, {buffer} as buffer
+                                /*Scope to a single record.*/
+                                WHERE store.id = buffer.model_uuid
+                                AND buffer.transfer_session_id = '{transfer_session_id}'
+                                /*Exclude fast-forwards*/
+                                AND NOT EXISTS (SELECT 1 FROM {rmcb} AS rmcb2 WHERE store.id = rmcb2.model_uuid
+                                                                              AND store.last_saved_instance = rmcb2.instance_id
+                                                                              AND store.last_saved_counter <= rmcb2.counter
+                                                                              AND rmcb2.transfer_session_id = '{transfer_session_id}')
+                                      """.format(buffer=Buffer._meta.db_table,
+                                                 rmcb=RecordMaxCounterBuffer._meta.db_table,
+                                                 store=Store._meta.db_table,
+                                                 rmc=RecordMaxCounter._meta.db_table,
+                                                 transfer_session_id=transfersession_id,
+                                                 current_instance_id=current_id.id,
+                                                 current_instance_counter=current_id.counter)
+        cursor.execute(merge_conflict_store)
+
+    def _dequeuing_insert_remaining_buffer(self, cursor, transfersession_id):
+        # insert remaining records into store
+        insert_remaining_buffer = """REPLACE INTO {store} (id, serialized, deleted, last_saved_instance, last_saved_counter,
+                                                               model_name, profile, partition, source_id, conflicting_serialized_data, dirty_bit, _self_ref_fk)
+                                    SELECT buffer.model_uuid, buffer.serialized, buffer.deleted, buffer.last_saved_instance, buffer.last_saved_counter,
+                                           buffer.model_name, buffer.profile, buffer.partition, buffer.source_id, buffer.conflicting_serialized_data, 1,
+                                           buffer._self_ref_fk
+                                    FROM {buffer} AS buffer
+                                    WHERE buffer.transfer_session_id = '{transfer_session_id}'
+                           """.format(buffer=Buffer._meta.db_table,
+                                      store=Store._meta.db_table,
+                                      transfer_session_id=transfersession_id)
+
+        cursor.execute(insert_remaining_buffer)
+
+    def _dequeuing_insert_remaining_rmcb(self, cursor, transfersession_id):
+        # insert remaining records into rmc
+        insert_remaining_rmcb = """REPLACE INTO {rmc} (instance_id, counter, store_model_id)
+                                    SELECT rmcb.instance_id, rmcb.counter, rmcb.model_uuid
+                                    FROM {rmcb} AS rmcb
+                                    WHERE rmcb.transfer_session_id = '{transfer_session_id}'
+                           """.format(rmc=RecordMaxCounter._meta.db_table,
+                                      rmcb=RecordMaxCounterBuffer._meta.db_table,
+                                      transfer_session_id=transfersession_id)
+
+        cursor.execute(insert_remaining_rmcb)

--- a/morango/utils/backends/sqlite.py
+++ b/morango/utils/backends/sqlite.py
@@ -1,4 +1,4 @@
-from base import BaseSQLWrapper
+from morango.utils.backends.base import BaseSQLWrapper
 from morango.models import (Buffer, RecordMaxCounter, RecordMaxCounterBuffer,
                             Store)
 

--- a/morango/utils/backends/utils.py
+++ b/morango/utils/backends/utils.py
@@ -1,0 +1,10 @@
+from importlib import import_module
+from morango.errors import MorangoError
+
+def load_backend(conn):
+
+    if 'postgresql' in conn.vendor:
+        return import_module('morango.utils.backends.postgres')
+    if 'sqlite' in conn.vendor:
+        return import_module('morango.utils.backends.sqlite')
+    raise MorangoError("Incompatible database backend for syncing")

--- a/morango/utils/sync_utils.py
+++ b/morango/utils/sync_utils.py
@@ -153,7 +153,7 @@ def _deserialize_from_store(profile):
             for klass in klass_model.morango_model_dependencies:
                 query |= Q(model_name=klass.morango_model_name)
             if self_ref_fk:
-                clean_parents = Store.objects.filter(dirty_bit=False, profile=profile).filter(query).annotate(id_cast=Cast('id', TextField())).annotate(fixed_id=Func(F('id_cast'), Value('-'), Value(''), function='replace',)).values_list("fixed_id", flat=True)
+                clean_parents = Store.objects.filter(dirty_bit=False, profile=profile).filter(query).char_ids_list()
                 dirty_children = Store.objects.filter(dirty_bit=True, profile=profile) \
                                               .filter(Q(_self_ref_fk__in=clean_parents) | Q(_self_ref_fk='')).filter(query)
 
@@ -166,7 +166,7 @@ def _deserialize_from_store(profile):
                         store_model.save(update_fields=['dirty_bit'])
 
                     # update lists with new clean parents and dirty children
-                    clean_parents = Store.objects.filter(dirty_bit=False, profile=profile).filter(query).annotate(id_cast=Cast('id', TextField())).annotate(fixed_id=Func(F('id_cast'), Value('-'), Value(''), function='replace',)).values_list("fixed_id", flat=True)
+                    clean_parents = Store.objects.filter(dirty_bit=False, profile=profile).filter(query).char_ids_list()
                     dirty_children = Store.objects.filter(dirty_bit=True, profile=profile, _self_ref_fk__in=clean_parents).filter(query)
             else:
                 for store_model in Store.objects.filter(model_name=model_name, profile=profile, dirty_bit=True):

--- a/morango/utils/sync_utils.py
+++ b/morango/utils/sync_utils.py
@@ -1,15 +1,20 @@
-import json
 import functools
+import json
 
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import connection, transaction
-from django.db.models import Q
+from django.db.models import F, Q, CharField, Func, TextField, Value
+from django.db.models.functions import Cast
 from django.utils.six import iteritems
 from morango.certificates import Filter
-from morango.models import Buffer, DatabaseMaxCounter, DeletedModels, InstanceIDModel, RecordMaxCounter, RecordMaxCounterBuffer, Store
+from morango.models import (Buffer, DatabaseMaxCounter, DeletedModels,
+                            InstanceIDModel, RecordMaxCounter,
+                            RecordMaxCounterBuffer, Store)
 from morango.utils.register_models import _profile_models
+from backends.utils import load_backend
 
+DBBackend = load_backend(connection).SQLWrapper()
 
 def _join_with_logical_operator(lst, operator):
     op = ") {operator} (".format(operator=operator)
@@ -95,7 +100,7 @@ def _serialize_into_store(profile, filter=None):
                         'partition': app_model._morango_partition,
                         'source_id': app_model._morango_source_id,
                     }
-                    # check if model has FK pointing to itand add the value to a field on the store
+                    # check if model has FK pointing to it and add the value to a field on the store
                     self_ref_fk = _self_referential_fk(klass_model)
                     if self_ref_fk:
                         self_ref_fk_value = getattr(app_model, self_ref_fk)
@@ -148,7 +153,7 @@ def _deserialize_from_store(profile):
             for klass in klass_model.morango_model_dependencies:
                 query |= Q(model_name=klass.morango_model_name)
             if self_ref_fk:
-                clean_parents = Store.objects.filter(dirty_bit=False, profile=profile).filter(query).values_list("id", flat=True)
+                clean_parents = Store.objects.filter(dirty_bit=False, profile=profile).filter(query).annotate(id_cast=Cast('id', TextField())).annotate(fixed_id=Func(F('id_cast'), Value('-'), Value(''), function='replace',)).values_list("fixed_id", flat=True)
                 dirty_children = Store.objects.filter(dirty_bit=True, profile=profile) \
                                               .filter(Q(_self_ref_fk__in=clean_parents) | Q(_self_ref_fk='')).filter(query)
 
@@ -161,7 +166,7 @@ def _deserialize_from_store(profile):
                         store_model.save(update_fields=['dirty_bit'])
 
                     # update lists with new clean parents and dirty children
-                    clean_parents = Store.objects.filter(dirty_bit=False, profile=profile).filter(query).values_list("id", flat=True)
+                    clean_parents = Store.objects.filter(dirty_bit=False, profile=profile).filter(query).annotate(id_cast=Cast('id', TextField())).annotate(fixed_id=Func(F('id_cast'), Value('-'), Value(''), function='replace',)).values_list("fixed_id", flat=True)
                     dirty_children = Store.objects.filter(dirty_bit=True, profile=profile, _self_ref_fk__in=clean_parents).filter(query)
             else:
                 for store_model in Store.objects.filter(model_name=model_name, profile=profile, dirty_bit=True):
@@ -212,10 +217,8 @@ def _queue_into_buffer(transfersession):
         queue_buffer = """INSERT INTO {outgoing_buffer}
                         (model_uuid, serialized, deleted, last_saved_instance, last_saved_counter,
                          model_name, profile, partition, source_id, conflicting_serialized_data, transfer_session_id, _self_ref_fk)
-                        SELECT id, serialized, deleted, last_saved_instance, last_saved_counter,
-                        model_name, profile, partition, source_id, conflicting_serialized_data, '{transfer_session_id}', _self_ref_fk
-                        FROM {store}
-                        WHERE {condition}""".format(outgoing_buffer=Buffer._meta.db_table,
+                        SELECT id, serialized, deleted, last_saved_instance, last_saved_counter, model_name, profile, partition, source_id, conflicting_serialized_data, '{transfer_session_id}', _self_ref_fk
+                        FROM {store} WHERE {condition}""".format(outgoing_buffer=Buffer._meta.db_table,
                                                     transfer_session_id=transfersession.id,
                                                     condition=where_condition,
                                                     store=Store._meta.db_table)
@@ -224,232 +227,31 @@ def _queue_into_buffer(transfersession):
         queue_rmc_buffer = """INSERT INTO {outgoing_rmcb}
                             (instance_id, counter, transfer_session_id, model_uuid)
                             SELECT instance_id, counter, '{transfer_session_id}', store_model_id
-                            FROM {record_max_counter} AS rmc LEFT JOIN {outgoing_buffer} AS buffer
-                            WHERE buffer.model_uuid = rmc.store_model_id
-                            AND buffer.transfer_session_id = '{transfer_session_id}'
+                            FROM {record_max_counter} AS rmc
+                            INNER JOIN {outgoing_buffer} AS buffer ON rmc.store_model_id = buffer.model_uuid AND rmc.instance_id = buffer.last_saved_instance
+                            WHERE buffer.transfer_session_id = '{transfer_session_id}'
                             """.format(outgoing_rmcb=RecordMaxCounterBuffer._meta.db_table,
                                        transfer_session_id=transfersession.id,
                                        record_max_counter=RecordMaxCounter._meta.db_table,
                                        outgoing_buffer=Buffer._meta.db_table)
         cursor.execute(queue_rmc_buffer)
 
-# START of dequeuing methods
-def _dequeuing_delete_rmcb_records(cursor, transfersession_id):
-    # delete all RMCBs which are a reverse FF (store version newer than buffer version)
-    delete_rmcb_records = """DELETE FROM {rmcb}
-                             WHERE model_uuid IN
-                             (SELECT rmcb.model_uuid FROM {store} as store, {buffer} as buffer, {rmc} as rmc, {rmcb} as rmcb
-                             /*Scope to a single record*/
-                             WHERE store.id = buffer.model_uuid
-                             AND  store.id = rmc.store_model_id
-                             AND  store.id = rmcb.model_uuid
-                             /*Checks whether LSB of buffer or less is in RMC of store*/
-                             AND buffer.last_saved_instance = rmc.instance_id
-                             AND buffer.last_saved_counter <= rmc.counter
-                             AND rmcb.transfer_session_id = '{transfer_session_id}'
-                             AND buffer.transfer_session_id = '{transfer_session_id}')
-                              """.format(buffer=Buffer._meta.db_table,
-                                         store=Store._meta.db_table,
-                                         rmc=RecordMaxCounter._meta.db_table,
-                                         rmcb=RecordMaxCounterBuffer._meta.db_table,
-                                         transfer_session_id=transfersession_id)
-
-    cursor.execute(delete_rmcb_records)
-
-def _dequeuing_delete_buffered_records(cursor, transfersession_id):
-    # delete all buffer records which are a reverse FF (store version newer than buffer version)
-    delete_buffered_records = """DELETE FROM {buffer}
-                                 WHERE model_uuid in
-                                 (SELECT buffer.model_uuid FROM {store} as store, {buffer} as buffer, {rmc} as rmc
-                                 /*Scope to a single record*/
-                                 WHERE store.id = buffer.model_uuid
-                                 AND rmc.store_model_id = buffer.model_uuid
-                                 /*Checks whether LSB of buffer or less is in RMC of store*/
-                                 AND buffer.last_saved_instance = rmc.instance_id
-                                 AND buffer.last_saved_counter <= rmc.counter
-                                 AND buffer.transfer_session_id = '{transfer_session_id}')
-                              """.format(buffer=Buffer._meta.db_table,
-                                         store=Store._meta.db_table,
-                                         rmc=RecordMaxCounter._meta.db_table,
-                                         rmcb=RecordMaxCounterBuffer._meta.db_table,
-                                         transfer_session_id=transfersession_id)
-    cursor.execute(delete_buffered_records)
-
-def _dequeuing_merge_conflict_rmcb(cursor, transfersession_id):
-    # transfer record max counters for records with merge conflicts + perform max
-    merge_conflict_rmc = """REPLACE INTO {rmc} (instance_id, counter, store_model_id)
-                                SELECT rmcb.instance_id, rmcb.counter, rmcb.model_uuid
-                                FROM {rmcb} AS rmcb, {store} AS store, {rmc} AS rmc, {buffer} AS buffer
-                                /*Scope to a single record.*/
-                                WHERE store.id = rmcb.model_uuid
-                                AND store.id = rmc.store_model_id
-                                AND store.id = buffer.model_uuid
-                                /*Where buffer rmc is greater than store rmc*/
-                                AND rmcb.instance_id = rmc.instance_id
-                                AND rmcb.counter > rmc.counter
-                                AND rmcb.transfer_session_id = '{transfer_session_id}'
-                                /*Exclude fast-forwards*/
-                                AND NOT EXISTS (SELECT 1 FROM {rmcb} AS rmcb2 WHERE store.id = rmcb2.model_uuid
-                                                                              AND store.last_saved_instance = rmcb2.instance_id
-                                                                              AND store.last_saved_counter <= rmcb2.counter
-                                                                              AND rmcb2.transfer_session_id = '{transfer_session_id}')
-                           """.format(buffer=Buffer._meta.db_table,
-                                      store=Store._meta.db_table,
-                                      rmc=RecordMaxCounter._meta.db_table,
-                                      rmcb=RecordMaxCounterBuffer._meta.db_table,
-                                      transfer_session_id=transfersession_id)
-    cursor.execute(merge_conflict_rmc)
-
-def _dequeuing_merge_conflict_buffer(cursor, current_id, transfersession_id):
-    # transfer buffer serialized into conflicting store
-    merge_conflict_store = """REPLACE INTO {store} (id, serialized, deleted, last_saved_instance, last_saved_counter, model_name,
-                                                    profile, partition, source_id, conflicting_serialized_data, dirty_bit, _self_ref_fk)
-                                        SELECT store.id, store.serialized, store.deleted OR buffer.deleted, '{current_instance_id}',
-                                               {current_instance_counter}, store.model_name, store.profile, store.partition, store.source_id,
-                                               buffer.serialized || '\n' || store.conflicting_serialized_data, 1, store._self_ref_fk
-                                        FROM {buffer} AS buffer, {store} AS store
-                                        /*Scope to a single record.*/
-                                        WHERE store.id = buffer.model_uuid
-                                        AND buffer.transfer_session_id = '{transfer_session_id}'
-                                        /*Exclude fast-forwards*/
-                                        AND NOT EXISTS (SELECT 1 FROM {rmcb} AS rmcb2 WHERE store.id = rmcb2.model_uuid
-                                                                                      AND store.last_saved_instance = rmcb2.instance_id
-                                                                                      AND store.last_saved_counter <= rmcb2.counter
-                                                                                      AND rmcb2.transfer_session_id = '{transfer_session_id}')
-                                  """.format(buffer=Buffer._meta.db_table,
-                                             rmcb=RecordMaxCounterBuffer._meta.db_table,
-                                             store=Store._meta.db_table,
-                                             rmc=RecordMaxCounter._meta.db_table,
-                                             transfer_session_id=transfersession_id,
-                                             current_instance_id=current_id.id,
-                                             current_instance_counter=current_id.counter)
-    cursor.execute(merge_conflict_store)
-
-def _dequeuing_update_rmcs_last_saved_by(cursor, current_id, transfersession_id):
-    # update or create rmc for merge conflicts with local instance id
-    merge_conflict_store = """REPLACE INTO {rmc} (instance_id, counter, store_model_id)
-                            SELECT '{current_instance_id}', {current_instance_counter}, store.id
-                            FROM {store} as store, {buffer} as buffer
-                            /*Scope to a single record.*/
-                            WHERE store.id = buffer.model_uuid
-                            AND buffer.transfer_session_id = '{transfer_session_id}'
-                            /*Exclude fast-forwards*/
-                            AND NOT EXISTS (SELECT 1 FROM {rmcb} AS rmcb2 WHERE store.id = rmcb2.model_uuid
-                                                                          AND store.last_saved_instance = rmcb2.instance_id
-                                                                          AND store.last_saved_counter <= rmcb2.counter
-                                                                          AND rmcb2.transfer_session_id = '{transfer_session_id}')
-                                  """.format(buffer=Buffer._meta.db_table,
-                                             rmcb=RecordMaxCounterBuffer._meta.db_table,
-                                             store=Store._meta.db_table,
-                                             rmc=RecordMaxCounter._meta.db_table,
-                                             transfer_session_id=transfersession_id,
-                                             current_instance_id=current_id.id,
-                                             current_instance_counter=current_id.counter)
-    cursor.execute(merge_conflict_store)
-
-def _dequeuing_delete_mc_buffer(cursor, transfersession_id):
-    # delete records with merge conflicts from buffer
-    delete_mc_buffer = """DELETE FROM {buffer}
-                                WHERE EXISTS
-                                (SELECT 1 FROM {store} AS store, {buffer} AS buffer
-                                /*Scope to a single record.*/
-                                WHERE store.id = {buffer}.model_uuid
-                                AND {buffer}.transfer_session_id = '{transfer_session_id}'
-                                /*Exclude fast-forwards*/
-                                AND NOT EXISTS (SELECT 1 FROM {rmcb} AS rmcb2 WHERE store.id = rmcb2.model_uuid
-                                                                              AND store.last_saved_instance = rmcb2.instance_id
-                                                                              AND store.last_saved_counter <= rmcb2.counter
-                                                                              AND rmcb2.transfer_session_id = '{transfer_session_id}'))
-                           """.format(buffer=Buffer._meta.db_table,
-                                      store=Store._meta.db_table,
-                                      rmc=RecordMaxCounter._meta.db_table,
-                                      rmcb=RecordMaxCounterBuffer._meta.db_table,
-                                      transfer_session_id=transfersession_id)
-    cursor.execute(delete_mc_buffer)
-
-def _dequeuing_delete_mc_rmcb(cursor, transfersession_id):
-    # delete rmcb records with merge conflicts
-    delete_mc_rmc = """DELETE FROM {rmcb}
-                                WHERE EXISTS
-                                (SELECT 1 FROM {store} AS store, {rmc} AS rmc
-                                /*Scope to a single record.*/
-                                WHERE store.id = {rmcb}.model_uuid
-                                AND store.id = rmc.store_model_id
-                                /*Where buffer rmc is greater than store rmc*/
-                                AND {rmcb}.instance_id = rmc.instance_id
-                                AND {rmcb}.transfer_session_id = '{transfer_session_id}'
-                                /*Exclude fast fast-forwards*/
-                                AND NOT EXISTS (SELECT 1 FROM {rmcb} AS rmcb2 WHERE store.id = rmcb2.model_uuid
-                                                                              AND store.last_saved_instance = rmcb2.instance_id
-                                                                              AND store.last_saved_counter <= rmcb2.counter
-                                                                              AND rmcb2.transfer_session_id = '{transfer_session_id}'))
-                           """.format(buffer=Buffer._meta.db_table,
-                                      store=Store._meta.db_table,
-                                      rmc=RecordMaxCounter._meta.db_table,
-                                      rmcb=RecordMaxCounterBuffer._meta.db_table,
-                                      transfer_session_id=transfersession_id)
-    cursor.execute(delete_mc_rmc)
-
-def _dequeuing_insert_remaining_buffer(cursor, transfersession_id):
-    # insert remaining records into store
-    insert_remaining_buffer = """REPLACE INTO {store} (id, serialized, deleted, last_saved_instance, last_saved_counter,
-                                                           model_name, profile, partition, source_id, conflicting_serialized_data, dirty_bit, _self_ref_fk)
-                                SELECT buffer.model_uuid, buffer.serialized, buffer.deleted, buffer.last_saved_instance, buffer.last_saved_counter,
-                                       buffer.model_name, buffer.profile, buffer.partition, buffer.source_id, buffer.conflicting_serialized_data, 1,
-                                       buffer._self_ref_fk
-                                FROM {buffer} AS buffer
-                                WHERE buffer.transfer_session_id = '{transfer_session_id}'
-                       """.format(buffer=Buffer._meta.db_table,
-                                  store=Store._meta.db_table,
-                                  transfer_session_id=transfersession_id)
-
-    cursor.execute(insert_remaining_buffer)
-
-def _dequeuing_insert_remaining_rmcb(cursor, transfersession_id):
-    # insert remaining records into rmc
-    insert_remaining_rmcb = """REPLACE INTO {rmc} (instance_id, counter, store_model_id)
-                                SELECT rmcb.instance_id, rmcb.counter, rmcb.model_uuid
-                                FROM {rmcb} AS rmcb
-                                WHERE rmcb.transfer_session_id = '{transfer_session_id}'
-                       """.format(rmc=RecordMaxCounter._meta.db_table,
-                                  rmcb=RecordMaxCounterBuffer._meta.db_table,
-                                  transfer_session_id=transfersession_id)
-
-    cursor.execute(insert_remaining_rmcb)
-
-def _dequeuing_delete_remaining_rmcb(cursor, transfersession_id):
-    # delete the rest for this transfer session
-    delete_remaining_rmcb = """DELETE FROM {rmcb}
-                              WHERE {rmcb}.transfer_session_id = '{transfer_session_id}'
-                           """.format(rmcb=RecordMaxCounterBuffer._meta.db_table,
-                                      transfer_session_id=transfersession_id)
-
-    cursor.execute(delete_remaining_rmcb)
-
-def _dequeuing_delete_remaining_buffer(cursor, transfersession_id):
-    delete_remaining_buffer = """DELETE FROM {buffer}
-                             WHERE {buffer}.transfer_session_id = '{transfer_session_id}'
-                          """.format(buffer=Buffer._meta.db_table,
-                                     transfer_session_id=transfersession_id)
-
-    cursor.execute(delete_remaining_buffer)
-
 def _dequeue_into_store(transfersession):
     """
     Takes data from the buffers and merges into the store and record max counters.
     """
     with connection.cursor() as cursor:
-        _dequeuing_delete_rmcb_records(cursor, transfersession.id)
-        _dequeuing_delete_buffered_records(cursor, transfersession.id)
+        DBBackend._dequeuing_delete_rmcb_records(cursor, transfersession.id)
+        DBBackend._dequeuing_delete_buffered_records(cursor, transfersession.id)
         current_id = InstanceIDModel.get_current_instance_and_increment_counter()
-        _dequeuing_merge_conflict_buffer(cursor, current_id, transfersession.id)
-        _dequeuing_merge_conflict_rmcb(cursor, transfersession.id)
-        _dequeuing_update_rmcs_last_saved_by(cursor, current_id, transfersession.id)
-        _dequeuing_delete_mc_rmcb(cursor, transfersession.id)
-        _dequeuing_delete_mc_buffer(cursor, transfersession.id)
-        _dequeuing_insert_remaining_buffer(cursor, transfersession.id)
-        _dequeuing_insert_remaining_rmcb(cursor, transfersession.id)
-        _dequeuing_delete_remaining_rmcb(cursor, transfersession.id)
-        _dequeuing_delete_remaining_buffer(cursor, transfersession.id)
+        DBBackend._dequeuing_merge_conflict_buffer(cursor, current_id, transfersession.id)
+        DBBackend._dequeuing_merge_conflict_rmcb(cursor, transfersession.id)
+        DBBackend._dequeuing_update_rmcs_last_saved_by(cursor, current_id, transfersession.id)
+        DBBackend._dequeuing_delete_mc_rmcb(cursor, transfersession.id)
+        DBBackend._dequeuing_delete_mc_buffer(cursor, transfersession.id)
+        DBBackend._dequeuing_insert_remaining_buffer(cursor, transfersession.id)
+        DBBackend._dequeuing_insert_remaining_rmcb(cursor, transfersession.id)
+        DBBackend._dequeuing_delete_remaining_rmcb(cursor, transfersession.id)
+        DBBackend._dequeuing_delete_remaining_buffer(cursor, transfersession.id)
     if getattr(settings, 'MORANGO_DESERIALIZE_AFTER_DEQUEUING', True):
         _deserialize_from_store(transfersession.sync_session.profile)

--- a/morango/utils/sync_utils.py
+++ b/morango/utils/sync_utils.py
@@ -12,7 +12,7 @@ from morango.models import (Buffer, DatabaseMaxCounter, DeletedModels,
                             InstanceIDModel, RecordMaxCounter,
                             RecordMaxCounterBuffer, Store)
 from morango.utils.register_models import _profile_models
-from backends.utils import load_backend
+from morango.utils.backends.utils import load_backend
 
 DBBackend = load_backend(connection).SQLWrapper()
 

--- a/morango/utils/sync_utils.py
+++ b/morango/utils/sync_utils.py
@@ -228,7 +228,7 @@ def _queue_into_buffer(transfersession):
                             (instance_id, counter, transfer_session_id, model_uuid)
                             SELECT instance_id, counter, '{transfer_session_id}', store_model_id
                             FROM {record_max_counter} AS rmc
-                            INNER JOIN {outgoing_buffer} AS buffer ON rmc.store_model_id = buffer.model_uuid AND rmc.instance_id = buffer.last_saved_instance
+                            INNER JOIN {outgoing_buffer} AS buffer ON rmc.store_model_id = buffer.model_uuid
                             WHERE buffer.transfer_session_id = '{transfer_session_id}'
                             """.format(outgoing_rmcb=RecordMaxCounterBuffer._meta.db_table,
                                        transfer_session_id=transfersession.id,

--- a/requirements/postgres.txt
+++ b/requirements/postgres.txt
@@ -1,0 +1,1 @@
+psycopg2

--- a/tests/testapp/testapp/postgres_test.py
+++ b/tests/testapp/testapp/postgres_test.py
@@ -1,0 +1,18 @@
+"""
+A settings module for running tests using a postgres db backend.
+"""
+from __future__ import absolute_import, print_function, unicode_literals
+
+from .settings import *  # noqa
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'USER': 'postgres',
+        'PASSWORD': '',
+        'NAME': 'default',  # This module should never be used outside of tests -- so this name is irrelevant
+        'TEST': {
+            'NAME': 'travis_ci_default'
+        }
+    },
+}

--- a/tests/testapp/tests/helpers.py
+++ b/tests/testapp/tests/helpers.py
@@ -188,7 +188,9 @@ def create_buffer_and_store_dummy_data(transfer_session_id):
     create_rmcb_data(1, 2, 3, 4, data['model4_rmcb_ids'], data['model4'], transfer_session_id)
 
     # buffer record with different transfer session id
+    session = SyncSession.objects.create(id=uuid.uuid4().hex, profile="", last_activity_timestamp=timezone.now())
     data['tfs_id'] = '9' * 32
+    TransferSession.objects.create(id=data['tfs_id'], sync_session=session, push=True, last_activity_timestamp=timezone.now())
     data['model6'] = 'f' * 32
     data['model6_rmcb_ids'] = setUpIds()
     BufferFactory(last_saved_instance=data['model6_rmcb_ids'][0], last_saved_counter=1, model_uuid=data['model6'], transfer_session_id=data['tfs_id'])

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
 
 [travis]
 python =
-  2.7: py27,lint
+  2.7: py27,lint, postgres
   3.4: py34
   3.5: py35
   3.6: py36
@@ -31,6 +31,8 @@ CRYPTOGRAPHY =
   2.0: cryptography20
 LINT =
   yes: lint
+POSTGRES =
+  yes: postgres
 
 [testenv]
 
@@ -47,6 +49,7 @@ basepython =
   py36: python3.6
   docs: python2.7
   lint: python2.7
+  postgres: python2.7
 
 deps =
   -r{toxinidir}/requirements/test.txt
@@ -63,4 +66,14 @@ deps =
 
 commands =
   sh -c '! tests/testapp/manage.py makemigrations --dry-run --exit --noinput'
+  py.test --cov=morango {posargs}
+
+[testenv:postgres]
+deps =
+  -r{toxinidir}/requirements/test.txt
+  psycopg2==2.7.4
+setenv =
+  PYTHONPATH = {toxinidir}:{toxinidir}/tests/testapp
+  DJANGO_SETTINGS_MODULE = testapp.postgres_test
+commands =
   py.test --cov=morango {posargs}


### PR DESCRIPTION
## Summary

Since there were some sqlite queries that did not work for postgres, this PR aims to rectify that. Depending on the database backend used, we route to the correct db specific SQL queries.

**Note: This is temporary until we add a SQLAlchemy layer to replace the raw SQL queries**

## TODO

- [x] Have tests been written for the new code? (same tests, but against postgres)
- [ ] Has documentation been written/updated?
- [x] New dependencies (if any) added to requirements file

## Reviewer guidance

https://github.com/ralphiee22/morango/blob/f6cfbc55d4c5c00a7de963c843d2e77750b66e9b/morango/utils/backends/postgres.py is probably of most interest, since that has the new postgres compatible SQL queries. Everything else is just a refactor to route to specific db backend.

## Issues addressed

SQL queries did not work on postgres, but now they do.