### PR TITLE
bulk create buffer objects as well

### DIFF
--- a/morango/api/serializers.py
+++ b/morango/api/serializers.py
@@ -71,6 +71,21 @@ class RecordMaxCounterBufferSerializer(serializers.ModelSerializer):
         fields = ('transfer_session', 'model_uuid', 'instance_id', 'counter')
 
 
+class BufferListSerializer(serializers.ListSerializer):
+
+    def create(self, validated_data):
+        # bulk create implementation
+        rmcb_list = []
+        buffer_list = []
+        for attrs in validated_data:
+            rmcb_list += [RecordMaxCounterBuffer(**rmcb_data) for rmcb_data in attrs.pop('rmcb_list')]
+            buffer_list += [Buffer(**attrs)]
+        with transaction.atomic():
+            buffers = Buffer.objects.bulk_create(buffer_list)
+            RecordMaxCounterBuffer.objects.bulk_create(rmcb_list)
+        return buffers
+
+
 class BufferSerializer(serializers.ModelSerializer):
 
     rmcb_list = RecordMaxCounterBufferSerializer(many=True)
@@ -118,3 +133,4 @@ class BufferSerializer(serializers.ModelSerializer):
     class Meta:
         model = Buffer
         fields = ('serialized', 'deleted', 'last_saved_instance', 'last_saved_counter', 'partition', 'source_id', 'model_name', 'conflicting_serialized_data', 'model_uuid', 'transfer_session', 'profile', 'rmcb_list', '_self_ref_fk')
+        list_serializer_class = BufferListSerializer

--- a/morango/utils/sync_utils.py
+++ b/morango/utils/sync_utils.py
@@ -161,7 +161,7 @@ def _deserialize_from_store(profile):
                 while len(dirty_children) > 0:
                     for store_model in dirty_children:
                         store_model._deserialize_store_model()
-                        # we update a store model after we have deserialized it
+                        # we update a store model after we have deserialized it to be able to mark it as a clean parent
                         store_model.dirty_bit = False
                         store_model.save(update_fields=['dirty_bit'])
 


### PR DESCRIPTION
## Summary

We go from saving each buffer object individually, to bulk saving them. Now we should only be doing 2 queries for **_creating/saving_** the records sent to the buffer endpoint. 

## Reviewer guidance

Do tests still pass?