### PR TITLE
Add the needed path to the cache file

### DIFF
--- a/morango/constants/file.py
+++ b/morango/constants/file.py
@@ -1,1 +1,6 @@
-SQLITE_VARIABLE_FILE_CACHE = 'SQLITE_MAX_VARIABLE_NUMBER.cache'
+import pwd
+import os
+
+SQLITE_VARIABLE_FILE_CACHE = os.path.join(pwd.getpwuid(os.getuid()).pw_dir,
+                                          'SQLITE_MAX_VARIABLE_NUMBER.cache')
+


### PR DESCRIPTION
## Summary

Current SQLITE_MAX_VARIABLE_NUMBER.cache is created in the same folder where kolibri is started. If the user does not have permissions on that folder, kolibri fails.

This is an important problem when running the kolibri daemon from the kolibri package, because it's executed this way:
`su kolibri -c "kolibri start"`
being `/` the execution folder.


This PR ensures this file is created in the user home dir.



## TODO

- [ ] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance
The issue is easy to reproduce just doing:
```
cd /var
kolibri --foreground start
```


## Issues addressed

Closes: #67 

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)
