### PR TITLE
pwd is not available in Windows

### DIFF
--- a/morango/constants/file.py
+++ b/morango/constants/file.py
@@ -1,6 +1,4 @@
-import pwd
 import os
 
-SQLITE_VARIABLE_FILE_CACHE = os.path.join(pwd.getpwuid(os.getuid()).pw_dir,
+SQLITE_VARIABLE_FILE_CACHE = os.path.join(os.path.expanduser('~'),
                                           'SQLITE_MAX_VARIABLE_NUMBER.cache')
-

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django<1.12
-django-mptt>=0.8.0
+django-mptt<0.10.0
 rsa>=3.4.2,<3.5
 djangorestframework>=3.3.3
 django-ipware>=1.1.6,<1.2


### PR DESCRIPTION
## Summary

Latest changes in file.py introduced a bug in Windows because it tries to use the `pwd` module , which is unix only. 

## Reviewer guidance

It's a simple check

## Issues addressed

Ensure a correct writable path is used

