### PR TITLE
Switch from file-based caching to Django's lru_cache for sqlite max vars

### DIFF
--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.4.5"
+__version__ = "0.4.6"

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.4.6"
+__version__ = "0.4.7"

--- a/morango/apps.py
+++ b/morango/apps.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import logging as logger
 
 from django.apps import AppConfig
-from django.db import connection
 
 from morango.utils.register_models import add_syncable_models
 

--- a/morango/apps.py
+++ b/morango/apps.py
@@ -5,7 +5,6 @@ import logging as logger
 from django.apps import AppConfig
 from django.db import connection
 
-from morango.util import max_parameter_substitution
 from morango.utils.register_models import add_syncable_models
 
 logging = logger.getLogger(__name__)
@@ -20,5 +19,3 @@ class MorangoConfig(AppConfig):
 
         # add models to be synced by profile
         add_syncable_models()
-        if "sqlite" in connection.vendor:
-            max_parameter_substitution()

--- a/morango/constants/file.py
+++ b/morango/constants/file.py
@@ -1,5 +1,0 @@
-import os
-
-SQLITE_VARIABLE_FILE_CACHE = os.path.join(
-    os.path.expanduser("~"), "SQLITE_MAX_VARIABLE_NUMBER.cache"
-)

--- a/morango/util.py
+++ b/morango/util.py
@@ -1,6 +1,5 @@
 import functools
 import logging
-import os
 import sqlite3
 
 from django.utils.lru_cache import lru_cache

--- a/morango/utils/backends/sqlite.py
+++ b/morango/utils/backends/sqlite.py
@@ -1,22 +1,15 @@
 import os
 
-from morango.constants.file import SQLITE_VARIABLE_FILE_CACHE
 from morango.models import Buffer
 from morango.models import RecordMaxCounter
 from morango.models import RecordMaxCounterBuffer
 from morango.models import Store
+from morango.util import calculate_max_sqlite_variables
 from morango.utils.backends.base import BaseSQLWrapper
 
 
 class SQLWrapper(BaseSQLWrapper):
     backend = "sqlite"
-
-    def __init__(self):
-        if os.path.isfile(SQLITE_VARIABLE_FILE_CACHE):
-            with open(SQLITE_VARIABLE_FILE_CACHE) as file:
-                self.SQLITE_MAX_VARIABLE_NUMBER = int(file.read())
-        else:
-            self.SQLITE_MAX_VARIABLE_NUMBER = 999
 
     def _bulk_insert_into_app_models(
         self, cursor, app_model, fields, db_values, placeholder_list
@@ -27,7 +20,7 @@ class SQLWrapper(BaseSQLWrapper):
         where values=[1,2,3,4,5,6,7,8,9]
         """
         # calculate and create equal sized chunks of data to insert incrementally
-        num_of_rows_able_to_insert = self.SQLITE_MAX_VARIABLE_NUMBER // len(fields)
+        num_of_rows_able_to_insert = calculate_max_sqlite_variables() // len(fields)
         num_of_values_able_to_insert = num_of_rows_able_to_insert * len(fields)
         value_chunks = [
             db_values[x : x + num_of_values_able_to_insert]


### PR DESCRIPTION
There were several issues arising in Kolibri as a result of the pesky `SQLITE_MAX_VARIABLE_NUMBER.cache` file, so this PR switches to just using Django's `lru_cache` to memoize the result of the function, so we can call it as many times as we want. It's not so expensive to compute the first time (70ms for me), and only needs to be run once per process, so I think this should be fine.