### PR TITLE
Split up `SyncClient` and fix bandwidth tracking

### DIFF
--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -39,23 +39,23 @@ sync process by a Morango instance I.
 
 Signaling
 ---------
-Morango fires a few different signals from ``SyncClient.signals`` during the sync process which can be used
-to track the progress of the sync. These signal groups are ``session``, ``queuing``,
-``pushing``, ``pulling``, and ``dequeuing``. Each signal group has 3 stages that can be
-fired: ``started``, ``in_progress``, and ``completed``. For a push or pull sync, the order of
-the fired signals would be as follows:
+Morango fires a few different signals from the ``signals`` object on both ``PullClient`` and
+``PushClient`` during the sync process which can be used to track the progress of the sync. These
+signal groups are ``session``, ``queuing``, ``transferring``, and ``dequeuing``. Each signal group
+has 3 stages that can be fired: ``started``, ``in_progress``, and ``completed``. For a push or pull
+sync, the order of the fired signals would be as follows:
 
-1) `TransferSession` started
+1) Session started
 2) Queuing started
 3) Queueing completed
-4) Pushing/Pulling started
-5) Pushing/Pulling in progress
-6) Pushing/Pulling completed
+4) Transferring started
+5) Transferring in progress
+6) Transferring completed
 7) Dequeuing started
 8) Dequeuing completed
-9) `TransferSession` completed
+9) Session completed
 
-.. autoclass:: morango.sync.syncsession.SyncClient
+.. autoclass:: morango.sync.syncsession.BaseSyncClient
     :members: signals
     :noindex:
 

--- a/morango/sync/operations.py
+++ b/morango/sync/operations.py
@@ -263,9 +263,7 @@ def _deserialize_from_store(profile, skip_erroring=False, filter=None):
         # iterate through classes which are in foreign key dependency order
         for model in syncable_models.get_models(profile):
 
-            store_models = Store.objects.filter(
-                profile=profile,
-            )
+            store_models = Store.objects.filter(profile=profile)
 
             model_condition = Q(model_name=model.morango_model_name)
             for klass in model.morango_model_dependencies:
@@ -495,5 +493,6 @@ def _dequeue_into_store(transfersession):
         DBBackend._dequeuing_delete_remaining_buffer(cursor, transfersession.id)
     if getattr(settings, "MORANGO_DESERIALIZE_AFTER_DEQUEUING", True):
         # we first serialize to avoid deserialization merge conflicts
-        _serialize_into_store(transfersession.sync_session.profile, filter=transfersession.get_filter())
-        _deserialize_from_store(transfersession.sync_session.profile)
+        filter = transfersession.get_filter()
+        _serialize_into_store(transfersession.sync_session.profile, filter=filter)
+        _deserialize_from_store(transfersession.sync_session.profile, filter=filter)

--- a/morango/sync/session.py
+++ b/morango/sync/session.py
@@ -1,5 +1,4 @@
 import logging
-from urllib.parse import urlparse
 
 from requests import exceptions
 from requests.sessions import Session

--- a/morango/sync/session.py
+++ b/morango/sync/session.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 from requests import exceptions
 from requests.sessions import Session
 from requests.utils import super_len
+from requests.packages.urllib3.util.url import parse_url
 
 
 logger = logging.getLogger(__name__)
@@ -43,7 +44,9 @@ class SessionWrapper(Session):
             if not content_length:
                 content_length = super_len(response.content)
 
-            self.bytes_received += len("HTTP/1.1 {} {}".format(response.status_code, response.reason))
+            self.bytes_received += len(
+                "HTTP/1.1 {} {}".format(response.status_code, response.reason)
+            )
             self.bytes_received += _length_of_headers(response.headers)
             self.bytes_received += content_length
 
@@ -68,7 +71,7 @@ class SessionWrapper(Session):
         :rtype: requests.PreparedRequest
         """
         prepped = super(SessionWrapper, self).prepare_request(request)
-        parsed_url = urlparse(request.url)
+        parsed_url = parse_url(request.url)
 
         # we don't bother checking if the content length header exists here because we've probably
         # been given the request body as Morango sends bodies that aren't streamed, so the

--- a/morango/sync/session.py
+++ b/morango/sync/session.py
@@ -19,7 +19,9 @@ def _headers_content_length(headers):
 
 
 def _length_of_headers(headers):
-    return super_len("\n".join(["{}: {}".format(key, value) for key, value in headers.items()]))
+    return super_len(
+        "\n".join(["{}: {}".format(key, value) for key, value in headers.items()])
+    )
 
 
 class SessionWrapper(Session):

--- a/morango/sync/session.py
+++ b/morango/sync/session.py
@@ -46,13 +46,15 @@ class SessionWrapper(Session):
 
             response.raise_for_status()
             return response
-        except exceptions.HTTPError as httpErr:
-            logger.error("{} Reason: {}".format(str(httpErr), httpErr.response.json()))
-            raise httpErr
-        except exceptions.RequestException as reqErr:
+        except exceptions.RequestException as req_err:
             # we want to log all request errors for debugging purposes
-            logger.error(str(reqErr))
-            raise reqErr
+            response_content = (
+                req_err.response.content if req_err.response else "(no response)"
+            )
+            logger.error(
+                "{} Reason: {}".format(req_err.__class__.__name__, response_content)
+            )
+            raise req_err
 
     def prepare_request(self, request):
         """

--- a/morango/sync/syncsession.py
+++ b/morango/sync/syncsession.py
@@ -30,7 +30,6 @@ from morango.errors import CertificateSignatureInvalid
 from morango.errors import MorangoError
 from morango.errors import MorangoServerDoesNotAllowNewCertPush
 from morango.models.certificates import Certificate
-from morango.models.certificates import Filter
 from morango.models.certificates import Key
 from morango.models.core import Buffer
 from morango.models.core import DatabaseMaxCounter

--- a/morango/sync/utils.py
+++ b/morango/sync/utils.py
@@ -70,7 +70,9 @@ class mute_signals(object):
         return wrapper
 
 
-def validate_and_create_buffer_data(data, transfer_session, connection=None):  # noqa: C901
+def validate_and_create_buffer_data(
+    data, transfer_session, connection=None
+):  # noqa: C901
     data = copy.deepcopy(data)
     rmcb_list = []
     buffer_list = []

--- a/morango/sync/utils.py
+++ b/morango/sync/utils.py
@@ -70,9 +70,7 @@ class mute_signals(object):
         return wrapper
 
 
-def validate_and_create_buffer_data(
-    data, transfer_session, connection=None
-):  # noqa: C901
+def validate_and_create_buffer_data(data, transfer_session, connection=None):  # noqa: C901
     data = copy.deepcopy(data)
     rmcb_list = []
     buffer_list = []

--- a/tests/testapp/tests/helpers.py
+++ b/tests/testapp/tests/helpers.py
@@ -23,7 +23,7 @@ from morango.models.core import Store
 from morango.models.core import SyncSession
 from morango.models.core import TransferSession
 from morango.sync.controller import MorangoProfileController
-from morango.sync.syncsession import SyncClient
+from morango.sync.syncsession import BaseSyncClient
 
 
 class FacilityFactory(factory.DjangoModelFactory):
@@ -69,11 +69,13 @@ def serialized_facility_factory(identifier):
 def create_dummy_store_data():
     data = {}
     DatabaseIDModel.objects.create()
-    data["group1_id"] = InstanceIDModel.get_or_create_current_instance()[0]  # counter is at 0
+    data["group1_id"] = InstanceIDModel.get_or_create_current_instance()[
+        0
+    ]  # counter is at 0
 
     # create controllers for app/store/buffer operations
     data["mc"] = MorangoProfileController("facilitydata")
-    data["sc"] = SyncClient(None, "host")
+    data["sc"] = BaseSyncClient(None, "host")
     session = SyncSession.objects.create(
         id=uuid.uuid4().hex,
         profile="facilitydata",
@@ -104,9 +106,11 @@ def create_dummy_store_data():
 
     # create new instance id and group of facilities
     with EnvironmentVarGuard() as env:
-        env['MORANGO_SYSTEM_ID'] = 'new_sys_id'
+        env["MORANGO_SYSTEM_ID"] = "new_sys_id"
 
-        data["group2_id"] = InstanceIDModel.get_or_create_current_instance()[0]  # new counter is at 0
+        data["group2_id"] = InstanceIDModel.get_or_create_current_instance()[
+            0
+        ]  # new counter is at 0
 
         data["mc"].serialize_into_store()  # new counter is at 1
         data["group2_c1"] = [FacilityFactory() for _ in range(5)]

--- a/tests/testapp/tests/test_connection.py
+++ b/tests/testapp/tests/test_connection.py
@@ -118,9 +118,13 @@ class NetworkSyncConnectionTestCase(LiveServerTestCase):
         mock_create.return_value = mock_session
 
         self.assertEqual(SyncSession.objects.filter(active=True).count(), 0)
-        first_client = self.network_connection.create_sync_session(self.subset_cert, self.root_cert)
+        first_client = self.network_connection.create_sync_session(
+            self.subset_cert, self.root_cert
+        )
         self.assertEqual(SyncSession.objects.filter(active=True).count(), 1)
-        second_client = self.network_connection.create_sync_session(self.subset_cert, self.root_cert)
+        second_client = self.network_connection.create_sync_session(
+            self.subset_cert, self.root_cert
+        )
         self.assertEqual(SyncSession.objects.filter(active=True).count(), 1)
 
         self.assertEqual(mock_session, first_client.sync_session)
@@ -391,7 +395,9 @@ class SyncClientTestCase(LiveServerTestCase):
 
         filter = ["abc123"]
         client.initiate_pull(filter)
-        MockPullClient.assert_called_with(self.conn, self.session, chunk_size=self.chunk_size)
+        MockPullClient.assert_called_with(
+            self.conn, self.session, chunk_size=self.chunk_size
+        )
 
         mock_pull_client.initialize.assert_called_once_with(filter)
         mock_pull_client.run.assert_called_once()
@@ -410,7 +416,9 @@ class SyncClientTestCase(LiveServerTestCase):
 
         filter = ["abc123"]
         client.initiate_push(filter)
-        MockPushClient.assert_called_with(self.conn, self.session, chunk_size=self.chunk_size)
+        MockPushClient.assert_called_with(
+            self.conn, self.session, chunk_size=self.chunk_size
+        )
 
         mock_pull_client.initialize.assert_called_once_with(filter)
         mock_pull_client.run.assert_called_once()
@@ -427,12 +435,21 @@ class SyncClientTestCase(LiveServerTestCase):
         client.close_sync_session()
         conn.close.assert_called_once()
 
-    @mock.patch("morango.sync.syncsession.NetworkSyncConnection._update_transfer_session")
+    @mock.patch(
+        "morango.sync.syncsession.NetworkSyncConnection._update_transfer_session"
+    )
     @mock.patch("morango.sync.syncsession._queue_into_buffer")
     @mock.patch("morango.sync.syncsession.BaseSyncClient._create_transfer_session")
     @mock.patch("morango.sync.syncsession._serialize_into_store")
     @mock.patch("morango.sync.syncsession.settings")
-    def test_push_client__initialize(self, mock_settings, mock_serialize, mock_parent_create, mock_queue, mock_transfer_update):
+    def test_push_client__initialize(
+        self,
+        mock_settings,
+        mock_serialize,
+        mock_parent_create,
+        mock_queue,
+        mock_transfer_update,
+    ):
         mock_handler = mock.Mock()
         client = self.build_client(PushClient)
         client.signals.queuing.connect(mock_handler)
@@ -440,11 +457,15 @@ class SyncClientTestCase(LiveServerTestCase):
         setattr(mock_settings, "MORANGO_SERIALIZE_BEFORE_QUEUING", True)
 
         client.initialize(sync_filter)
-        mock_serialize.assert_called_with(self.session.profile, filter=Filter(sync_filter))
+        mock_serialize.assert_called_with(
+            self.session.profile, filter=Filter(sync_filter)
+        )
         mock_parent_create.assert_called_with(sync_filter, push=True)
         mock_queue.assert_called_with(client.current_transfer_session)
         mock_transfer_update.assert_called_once_with(
-            {"records_total": client.current_transfer_session.records_total}, client.current_transfer_session)
+            {"records_total": client.current_transfer_session.records_total},
+            client.current_transfer_session,
+        )
 
         mock_handler.assert_any_call(transfer_session=client.current_transfer_session)
 
@@ -455,7 +476,9 @@ class SyncClientTestCase(LiveServerTestCase):
         client.run()
 
         mock_push.assert_called_once()
-        self.transferring_mock.assert_called_with(transfer_session=client.current_transfer_session)
+        self.transferring_mock.assert_called_with(
+            transfer_session=client.current_transfer_session
+        )
 
     @mock.patch("morango.sync.syncsession.PushClient._push_records")
     def test_push_client__run__no_records(self, mock_push):
@@ -490,7 +513,9 @@ class SyncClientTestCase(LiveServerTestCase):
         client.run()
 
         mock_pull.assert_called_once()
-        self.transferring_mock.assert_called_with(transfer_session=client.current_transfer_session)
+        self.transferring_mock.assert_called_with(
+            transfer_session=client.current_transfer_session
+        )
 
     @mock.patch("morango.sync.syncsession.PullClient._pull_records")
     def test_pull_client__run__no_records(self, mock_pull):
@@ -513,8 +538,12 @@ class SyncClientTestCase(LiveServerTestCase):
         mock_handler.assert_any_call(transfer_session=client.current_transfer_session)
         mock_close.assert_called_once()
 
-    @mock.patch("morango.sync.syncsession.BaseSyncClient._initialize_server_transfer_session")
-    def test_pull_client__initialize_server_transfer_session(self, mock_parent_initialize):
+    @mock.patch(
+        "morango.sync.syncsession.BaseSyncClient._initialize_server_transfer_session"
+    )
+    def test_pull_client__initialize_server_transfer_session(
+        self, mock_parent_initialize
+    ):
         mock_handler = mock.Mock()
         mock_response = mock.Mock()
 

--- a/tests/testapp/tests/test_connection.py
+++ b/tests/testapp/tests/test_connection.py
@@ -8,6 +8,7 @@ from django.test.utils import override_settings
 from django.utils import timezone
 from facility_profile.models import SummaryLog
 from requests.exceptions import HTTPError
+from requests.exceptions import RequestException
 
 from morango.api.serializers import BufferSerializer
 from morango.api.serializers import CertificateSerializer
@@ -559,7 +560,7 @@ class SyncClientTestCase(LiveServerTestCase):
 
 
 class SessionWrapperTestCase(TestCase):
-    @mock.patch("requests.sessions.Session.request")
+    @mock.patch("morango.sync.session.Session.request")
     def test_request(self, mocked_super_request):
         headers = {"Content-Length": 1024}
         expected = mocked_super_request.return_value = mock.Mock(
@@ -573,7 +574,49 @@ class SessionWrapperTestCase(TestCase):
 
         self.assertEqual(wrapper.bytes_received, 1024 + _length_of_headers(headers))
 
-    @mock.patch("requests.sessions.Session.prepare_request")
+    @mock.patch("morango.sync.session.logger")
+    @mock.patch("morango.sync.session.Session.request")
+    def test_request__not_ok(self, mocked_super_request, mocked_logger):
+        raise_for_status = mock.Mock()
+        expected = mocked_super_request.return_value = mock.Mock(
+            headers={"Content-Length": 1024},
+            raise_for_status=raise_for_status,
+            content="Connection timeout",
+        )
+
+        raise_for_status.side_effect = HTTPError(response=expected)
+
+        wrapper = SessionWrapper()
+
+        with self.assertRaises(HTTPError):
+            wrapper.request("GET", "test_url", is_test=True)
+
+        mocked_super_request.assert_called_once_with("GET", "test_url", is_test=True)
+        mocked_logger.error.assert_called_once_with(
+            "HTTPError Reason: Connection timeout"
+        )
+
+    @mock.patch("morango.sync.session.logger")
+    @mock.patch("morango.sync.session.Session.request")
+    def test_request__really_not_ok(self, mocked_super_request, mocked_logger):
+        raise_for_status = mock.Mock()
+        mocked_super_request.return_value = mock.Mock(
+            headers={"Content-Length": 1024}, raise_for_status=raise_for_status,
+        )
+
+        raise_for_status.side_effect = RequestException()
+
+        wrapper = SessionWrapper()
+
+        with self.assertRaises(RequestException):
+            wrapper.request("GET", "test_url", is_test=True)
+
+        mocked_super_request.assert_called_once_with("GET", "test_url", is_test=True)
+        mocked_logger.error.assert_called_once_with(
+            "RequestException Reason: (no response)"
+        )
+
+    @mock.patch("morango.sync.session.Session.prepare_request")
     def test_prepare_request(self, mocked_super_prepare_request):
         headers = {"Content-Length": 256}
         expected = mocked_super_prepare_request.return_value = mock.Mock(

--- a/tests/testapp/tests/test_connection.py
+++ b/tests/testapp/tests/test_connection.py
@@ -419,7 +419,7 @@ class SyncClientTestCase(LiveServerTestCase):
         MockPullClient.return_value = mock_pull_client
         client = self.build_client(SyncClient)
 
-        filter = ["abc123"]
+        filter = Filter("abc123")
         client.initiate_pull(filter)
         MockPullClient.assert_called_with(
             self.conn, self.session, chunk_size=self.chunk_size
@@ -440,13 +440,13 @@ class SyncClientTestCase(LiveServerTestCase):
         MockPushClient.return_value = mock_pull_client
         client = self.build_client(SyncClient)
 
-        filter = ["abc123"]
-        client.initiate_push(filter)
+        sync_filter = Filter("abc123")
+        client.initiate_push(sync_filter)
         MockPushClient.assert_called_with(
             self.conn, self.session, chunk_size=self.chunk_size
         )
 
-        mock_pull_client.initialize.assert_called_once_with(filter)
+        mock_pull_client.initialize.assert_called_once_with(sync_filter)
         mock_pull_client.run.assert_called_once()
         mock_pull_client.finalize.assert_called_once()
 
@@ -479,13 +479,11 @@ class SyncClientTestCase(LiveServerTestCase):
         mock_handler = mock.Mock()
         client = self.build_client(PushClient)
         client.signals.queuing.connect(mock_handler)
-        sync_filter = "abc123"
+        sync_filter = Filter("abc123")
         setattr(mock_settings, "MORANGO_SERIALIZE_BEFORE_QUEUING", True)
 
         client.initialize(sync_filter)
-        mock_serialize.assert_called_with(
-            self.session.profile, filter=Filter(sync_filter)
-        )
+        mock_serialize.assert_called_with(self.session.profile, filter=sync_filter)
         mock_parent_create.assert_called_with(sync_filter, push=True)
         mock_queue.assert_called_with(client.current_transfer_session)
         mock_transfer_update.assert_called_once_with(
@@ -526,7 +524,7 @@ class SyncClientTestCase(LiveServerTestCase):
     @mock.patch("morango.sync.syncsession.BaseSyncClient._create_transfer_session")
     def test_pull_client__initialize(self, mock_parent_create):
         client = self.build_client(PullClient)
-        sync_filter = "abc123"
+        sync_filter = Filter("abc123")
 
         client.initialize(sync_filter)
         self.assertEqual(sync_filter, client.sync_filter)
@@ -556,7 +554,7 @@ class SyncClientTestCase(LiveServerTestCase):
         mock_handler = mock.Mock()
         client = self.build_client(PullClient)
         client.signals.dequeuing.connect(mock_handler)
-        client.sync_filter = "abc123"
+        client.sync_filter = Filter("abc123")
         client.current_transfer_session.server_fsic = "{}"
         client.finalize()
 

--- a/tests/testapp/tests/test_syncsession_methods.py
+++ b/tests/testapp/tests/test_syncsession_methods.py
@@ -24,6 +24,7 @@ from morango.sync.controller import MorangoProfileController
 from morango.sync.operations import _dequeue_into_store
 from morango.sync.operations import _queue_into_buffer
 from morango.sync.syncsession import BaseSyncClient
+from morango.sync.syncsession import SyncClientSignals
 from morango.sync.syncsession import SyncSignal
 from morango.sync.syncsession import SyncSignalGroup
 
@@ -569,3 +570,19 @@ class SyncSignalGroupTestCase(TestCase):
             completed_handler.assert_not_called()
 
         completed_handler.assert_called_once_with(this_is_a_default=True, other="A")
+
+
+class SyncClientSignalsTestCase(TestCase):
+    def test_separation(self):
+        handler1 = mock.Mock()
+        signals1 = SyncClientSignals()
+        signals1.session.connect(handler1)
+
+        handler2 = mock.Mock()
+        signals2 = SyncClientSignals()
+        signals2.session.connect(handler2)
+
+        signals1.session.fire()
+        handler1.assert_called_once_with(transfer_session=None)
+        handler2.assert_not_called()
+

--- a/tests/testapp/tests/test_syncsession_methods.py
+++ b/tests/testapp/tests/test_syncsession_methods.py
@@ -23,7 +23,7 @@ from morango.sync.backends.utils import load_backend
 from morango.sync.controller import MorangoProfileController
 from morango.sync.operations import _dequeue_into_store
 from morango.sync.operations import _queue_into_buffer
-from morango.sync.syncsession import SyncClient
+from morango.sync.syncsession import BaseSyncClient
 from morango.sync.syncsession import SyncSignal
 from morango.sync.syncsession import SyncSignalGroup
 
@@ -152,7 +152,7 @@ class BufferIntoStoreTestCase(TestCase):
 
         # create controllers for app/store/buffer operations
         self.data["mc"] = MorangoProfileController("facilitydata")
-        self.data["sc"] = SyncClient(None, "host")
+        self.data["sc"] = BaseSyncClient(None, "host")
         session = SyncSession.objects.create(
             id=uuid.uuid4().hex, profile="", last_activity_timestamp=timezone.now()
         )

--- a/tests/testapp/tests/test_syncsession_methods.py
+++ b/tests/testapp/tests/test_syncsession_methods.py
@@ -585,4 +585,3 @@ class SyncClientSignalsTestCase(TestCase):
         signals1.session.fire()
         handler1.assert_called_once_with(transfer_session=None)
         handler2.assert_not_called()
-


### PR DESCRIPTION
## Summary
Splits up the `SyncClient` class into a base class and two classes for each sync direction, `PullClient` and `PushClient`. This will enable us to better handling any database locking that should occur during the sync stages. I've left a small wrapper class in place for `SyncClient` such that this change should be backwards compatible for now.

This also fixes bandwidth tracking by attempting to track the response body size if there isn't a `Content-Length` header. It also now tracks the headers to get a better estimate of the entire request/response size.

Additionally, this fixes request exception handling in the `SessionWrapper`. Firstly, it was casting errors to strings which the errors being captured don't have a `__str__` method defined, so it now simply logs the error class name. Also, it's more defensive on accessing the response from the error since it was always assuming it existed and that it was JSON.

Lastly, this adds a condition to only dequeue from the API to delete a transfer session when the session actually had records. This avoids a lengthy, serialize and then deserialize within the dequeue function when it's unnecessary.

## TODO

- [X] Have tests been written for the new code?
- [X] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance
This will be most easily tested when integrated with Kolibri

## Issues addressed
Related to https://github.com/learningequality/kolibri/issues/7125
