### PR TITLE
Don't die on session deletion when transfersession.records_total is None

### DIFF
--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.5.3"
+__version__ = "0.5.4"

--- a/morango/api/viewsets.py
+++ b/morango/api/viewsets.py
@@ -390,7 +390,10 @@ class TransferSessionViewSet(viewsets.ModelViewSet):
     def perform_destroy(self, transfersession):
         if transfersession.push:
             # if no records were transferred, we can safely skip the next steps
-            if transfersession.records_total > 0:
+            if (
+                transfersession.records_total is not None
+                and transfersession.records_total > 0
+            ):
                 # dequeue into store and then delete records
                 with OperationLogger(
                     "Dequeuing records into store", "Dequeuing complete"

--- a/tests/testapp/tests/test_api.py
+++ b/tests/testapp/tests/test_api.py
@@ -647,6 +647,20 @@ class TransferSessionEndpointTestCase(CertificateTestCaseMixin, APITestCase):
         transfersession = TransferSession.objects.get()
         self.assertEqual(transfersession.active, True)
 
+        self._delete_transfer_session(transfersession)
+
+    def test_transfersession_with_null_records_total_can_be_deleted(self):
+
+        self.test_transfersession_can_be_created()
+
+        transfersession = TransferSession.objects.get()
+        transfersession.records_total = None
+        transfersession.save()
+
+        self._delete_transfer_session(transfersession)
+
+    def _delete_transfer_session(self, transfersession):
+
         response = self.client.delete(reverse('transfersessions-detail', kwargs={"pk": transfersession.id}), format='json')
         self.assertEqual(response.status_code, 204)
 


### PR DESCRIPTION
## Summary

We were seeing this Exception on KDP, when `records_total` was `None`: `'>' not supported between instances of 'NoneType' and 'int'`.

https://sentry.io/organizations/learningequality/issues/1786330759/?project=1486197&query=is%3Aunresolved&sort=freq&statsPeriod=14d

## TODO

- [x] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file