### PR TITLE
Allow MAC address to be overridden by envvar for instance_id calculation

### DIFF
--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.5.4"
+__version__ = "0.5.5"

--- a/morango/models/core.py
+++ b/morango/models/core.py
@@ -157,7 +157,7 @@ class InstanceIDModel(models.Model):
             kwargs["current"] = True
 
             # ensure we only ever have 1 current instance ID
-            InstanceIDModel.objects.exclude(id=kwargs["id"], current=False).update(
+            InstanceIDModel.objects.filter(current=True).exclude(id=kwargs["id"]).update(
                 current=False
             )
             # create the model, or get existing if one already exists with this ID

--- a/morango/models/utils.py
+++ b/morango/models/utils.py
@@ -205,6 +205,11 @@ def _mac_is_local(mac):
 
 def get_0_5_mac_address():
 
+    # check whether envvar was set, and use that if available
+    node_id = os.environ.get("MORANGO_NODE_ID")
+    if node_id and len(node_id.strip()) >= 3:
+        return _do_salted_hash(node_id)
+
     # first, try using ifcfg
     interfaces = []
     try:
@@ -218,9 +223,8 @@ def get_0_5_mac_address():
 
     # fall back to trying uuid.getnode
     mac = uuid.getnode()
-    if not _mac_is_multicast(
-        mac
-    ):  # when uuid.getnode returns a fake MAC, it marks as multicast
+    # when uuid.getnode returns a fake MAC, it marks as multicast
+    if not _mac_is_multicast(mac):
         return _do_salted_hash(_mac_int_to_ether(mac))
 
     return ""


### PR DESCRIPTION
## Summary

On KDP (or in Docker-based distributions more broadly), the detected MAC address is randomly generated, leading to regeneration of the instance_id more frequently than is desired (and in some cases, database lockups, in a multi-node setup). This PR allows the detected MAC value to be overridden with a fixed value, to increase the instance_id stability in these environments.

## TODO

- [x] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file
