### PR TITLE
remove the order_by id clause on syncing

### DIFF
--- a/morango/sync/syncsession.py
+++ b/morango/sync/syncsession.py
@@ -644,7 +644,7 @@ class PushClient(BaseSyncClient):
         # paginate buffered records so we do not load them all into memory
         buffered_records = Buffer.objects.filter(
             transfer_session=self.current_transfer_session
-        ).order_by("pk")
+        )
         buffered_pages = Paginator(buffered_records, self.chunk_size)
 
         for count in buffered_pages.page_range:


### PR DESCRIPTION
In cloud kolibri we have a massive table[1], and adding this clause makes the queryset time out. Removing this clause makes the queryset succeed and continues the sycning process.

[Here's the related sentry error](https://sentry.io/organizations/learningequality/issues/1991509416/?project=1378215&query=is%3Aunresolved).

I did get this warning upon removing this clause:

```
/usr/local/lib/python2.7/dist-packages/kolibri/dist/morango/sync/syncsession.py:508: UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: <class 'morango.models.core.Buffer'> QuerySet.
  buffered_pages = Paginator(buffered_records, self.chunk_size)
```

Let me know if this warning is too big to ignore.



[1] massive enough that a COUNT(*) takes longer than 60 seconds and times out.