### PR TITLE
Add management command to close old sessions and clear out the buffers

### DIFF
--- a/morango/management/commands/cleanupsyncs.py
+++ b/morango/management/commands/cleanupsyncs.py
@@ -1,0 +1,60 @@
+import datetime
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+from django.db import transaction
+from django.utils import timezone
+
+from morango.models import *
+
+
+class Command(BaseCommand):
+    help = "Closes and cleans up the data for any incomplete sync sessions older than a certain number of hours."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--expiration",
+            action="store",
+            type=int,
+            default=6,
+            help="Number of hours of inactivity after which a session should be considered stale",
+        )
+
+    def handle(self, *args, **options):
+
+        # establish the cutoff time and date for stale sessions
+        cutoff = timezone.now() - datetime.timedelta(hours=options["expiration"])
+
+        # retrieve all sessions still marked as active but with no activity since the cutoff
+        oldsessions = TransferSession.objects.filter(
+            last_activity_timestamp__lt=cutoff, active=True
+        )
+        sesscount = oldsessions.count()
+
+        # loop over the stale sessions one by one to close them out
+        for i in range(sesscount):
+            sess = oldsessions[0]
+            print(
+                "Session {} of {}: deleting {} Buffers and {} RMC Buffers...".format(
+                    i + 1,
+                    sesscount,
+                    sess.buffer_set.all().count(),
+                    sess.recordmaxcounterbuffer_set.all().count(),
+                )
+            )
+
+            # delete buffer data and mark session as inactive
+            with transaction.atomic():
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        "DELETE FROM morango_buffer WHERE transfer_session_id = %s",
+                        (sess.id,),
+                    )
+                    cursor.execute(
+                        "DELETE FROM morango_recordmaxcounterbuffer WHERE transfer_session_id = %s",
+                        (sess.id,),
+                    )
+                sess.active = False
+                sess.save()
+                sess.sync_session.active = False
+                sess.sync_session.save()

--- a/tests/testapp/tests/helpers.py
+++ b/tests/testapp/tests/helpers.py
@@ -144,14 +144,8 @@ def create_dummy_store_data():
     return data
 
 
-def setUpIds(common_id=True):
-
-    if common_id:
-        data = ["1" * 32]
-    else:
-        data = [uuid.uuid4().hex]
-    data = data + [uuid.uuid4().hex for _ in range(3)]
-    return data
+def random_ids(count):
+    return [uuid.uuid4().hex for _ in range(count)]
 
 
 def create_rmc_data(c1, c2, c3, c4, ids, model_id):
@@ -168,9 +162,12 @@ def create_rmcb_data(c1, c2, c3, c4, ids, model_id, ts):
 
 def create_buffer_and_store_dummy_data(transfer_session_id):
     data = {}
+    common_id = [uuid.uuid4().hex]
+
     # example data for reverse ff
-    data["model1"] = "a" * 32
-    data["model1_rmc_ids"] = setUpIds()
+    data["model1"] = uuid.uuid4().hex
+    data["model1_rmc_ids"] = common_id + random_ids(3)
+
     # store1: last_saved => D: 3
     # RMCs A: 3, B: 1, C: 2, D: 3
     StoreFactory(
@@ -180,7 +177,7 @@ def create_buffer_and_store_dummy_data(transfer_session_id):
         id=data["model1"],
     )
     create_rmc_data(3, 1, 2, 3, data["model1_rmc_ids"], data["model1"])
-    data["model1_rmcb_ids"] = setUpIds()
+    data["model1_rmcb_ids"] = common_id + random_ids(3)
     # buffer1: last_saved => A: 1
     # RMCBs A: 1, F: 2, G: 3, H: 4
     BufferFactory(
@@ -195,8 +192,8 @@ def create_buffer_and_store_dummy_data(transfer_session_id):
     )
 
     # example data for merge conflict (rmcb.counter > rmc.counter)
-    data["model2"] = "b" * 32
-    data["model2_rmc_ids"] = setUpIds()
+    data["model2"] = uuid.uuid4().hex
+    data["model2_rmc_ids"] = common_id + random_ids(3)
     # store2: last_saved => C: 2
     # RMCs A: 1, B: 1, C: 2, D: 3
     StoreFactory(
@@ -207,7 +204,7 @@ def create_buffer_and_store_dummy_data(transfer_session_id):
         conflicting_serialized_data="store",
     )
     create_rmc_data(1, 1, 2, 3, data["model2_rmc_ids"], data["model2"])
-    data["model2_rmcb_ids"] = setUpIds()
+    data["model2_rmcb_ids"] = common_id + random_ids(3)
     # buffer2: last_saved => F: 2
     # RMCBs A: 3, F: 2, G: 3, H: 4
     BufferFactory(
@@ -223,8 +220,8 @@ def create_buffer_and_store_dummy_data(transfer_session_id):
     )
 
     # example data for merge conflict (rmcb.counter <= rmc.counter)
-    data["model5"] = "e" * 32
-    data["model5_rmc_ids"] = setUpIds()
+    data["model5"] = uuid.uuid4().hex
+    data["model5_rmc_ids"] = common_id + random_ids(3)
     # store5: last_saved => C: 2
     # RMCs A: 3, B: 1, C: 2, D: 3
     StoreFactory(
@@ -235,7 +232,7 @@ def create_buffer_and_store_dummy_data(transfer_session_id):
         conflicting_serialized_data="store",
     )
     create_rmc_data(3, 1, 2, 3, data["model5_rmc_ids"], data["model5"])
-    data["model5_rmcb_ids"] = setUpIds()
+    data["model5_rmcb_ids"] = common_id + random_ids(3)
     # buffer5: last_saved => F: 2
     # RMCBs A: 1, F: 2, G: 3, H: 4
     BufferFactory(
@@ -250,8 +247,8 @@ def create_buffer_and_store_dummy_data(transfer_session_id):
     )
 
     # example data for merge conflict with hard delete(rmcb.counter <= rmc.counter)
-    data["model7"] = "8" * 32
-    data["model7_rmc_ids"] = setUpIds()
+    data["model7"] = uuid.uuid4().hex
+    data["model7_rmc_ids"] = common_id + random_ids(3)
     # store5: last_saved => C: 2
     # RMCs A: 3, B: 1, C: 2, D: 3
     StoreFactory(
@@ -262,7 +259,7 @@ def create_buffer_and_store_dummy_data(transfer_session_id):
         conflicting_serialized_data="store",
     )
     create_rmc_data(3, 1, 2, 3, data["model7_rmc_ids"], data["model7"])
-    data["model7_rmcb_ids"] = setUpIds()
+    data["model7_rmcb_ids"] = common_id + random_ids(3)
     # buffer5: last_saved => F: 2
     # RMCBs A: 1, F: 2, G: 3, H: 4
     BufferFactory(
@@ -278,8 +275,8 @@ def create_buffer_and_store_dummy_data(transfer_session_id):
     )
 
     # example data for ff
-    data["model3"] = "c" * 32
-    data["model3_rmc_ids"] = setUpIds()
+    data["model3"] = uuid.uuid4().hex
+    data["model3_rmc_ids"] = common_id + random_ids(3)
     # store3: last_saved => A: 1
     # RMCs A: 1, B: 2, C: 3, D: 4
     StoreFactory(
@@ -289,7 +286,7 @@ def create_buffer_and_store_dummy_data(transfer_session_id):
         id=data["model3"],
     )
     create_rmc_data(1, 2, 3, 4, data["model3_rmc_ids"], data["model3"])
-    data["model3_rmcb_ids"] = setUpIds()
+    data["model3_rmcb_ids"] = common_id + random_ids(3)
     # buffer3: last_saved => F: 2
     # RMCBs A: 3, F: 2, G: 3, H: 4
     BufferFactory(
@@ -304,8 +301,8 @@ def create_buffer_and_store_dummy_data(transfer_session_id):
     )
 
     # example for missing store data
-    data["model4"] = "d" * 32
-    data["model4_rmcb_ids"] = setUpIds()
+    data["model4"] = uuid.uuid4().hex
+    data["model4_rmcb_ids"] = common_id + random_ids(3)
     BufferFactory(
         serialized="buffer",
         last_saved_instance=data["model4_rmcb_ids"][0],
@@ -321,15 +318,15 @@ def create_buffer_and_store_dummy_data(transfer_session_id):
     session = SyncSession.objects.create(
         id=uuid.uuid4().hex, profile="", last_activity_timestamp=timezone.now()
     )
-    data["tfs_id"] = "9" * 32
+    data["tfs_id"] = uuid.uuid4().hex
     TransferSession.objects.create(
         id=data["tfs_id"],
         sync_session=session,
         push=True,
         last_activity_timestamp=timezone.now(),
     )
-    data["model6"] = "f" * 32
-    data["model6_rmcb_ids"] = setUpIds()
+    data["model6"] = uuid.uuid4().hex
+    data["model6_rmcb_ids"] = common_id + random_ids(3)
     BufferFactory(
         last_saved_instance=data["model6_rmcb_ids"][0],
         last_saved_counter=1,

--- a/tests/testapp/tests/test_management_commands.py
+++ b/tests/testapp/tests/test_management_commands.py
@@ -1,0 +1,74 @@
+import datetime
+import uuid
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from .helpers import create_buffer_and_store_dummy_data
+from morango.models.core import Buffer
+from morango.models.core import RecordMaxCounterBuffer
+from morango.models.core import SyncSession
+from morango.models.core import TransferSession
+
+
+def _create_sessions(last_activity_offset=0):
+
+    last_activity_timestamp = timezone.now() - datetime.timedelta(
+        hours=last_activity_offset
+    )
+
+    sync_session = SyncSession.objects.create(
+        id=uuid.uuid4().hex,
+        profile="facilitydata",
+        last_activity_timestamp=last_activity_timestamp,
+    )
+    transfer_session = TransferSession.objects.create(
+        id=uuid.uuid4().hex,
+        sync_session=sync_session,
+        push=True,
+        last_activity_timestamp=last_activity_timestamp,
+    )
+
+    return sync_session, transfer_session
+
+
+def assert_session_is_cleared(transfersession):
+    transfersession.refresh_from_db()
+    transfersession.sync_session.refresh_from_db()
+    assert transfersession.buffer_set.all().count() == 0
+    assert transfersession.recordmaxcounterbuffer_set.all().count() == 0
+    assert transfersession.active == False
+    assert transfersession.sync_session.active == False
+
+
+def assert_session_is_not_cleared(transfersession):
+    transfersession.refresh_from_db()
+    transfersession.sync_session.refresh_from_db()
+    assert transfersession.buffer_set.all().count() > 0
+    assert transfersession.recordmaxcounterbuffer_set.all().count() > 0
+    assert transfersession.active == True
+    assert transfersession.sync_session.active == True
+
+
+class CleanupSyncsTestCase(TestCase):
+    def setUp(self):
+        self.syncsession_old, self.transfersession_old = _create_sessions(24)
+        self.syncsession_new, self.transfersession_new = _create_sessions(2)
+        self.data_old = create_buffer_and_store_dummy_data(self.transfersession_old.id)
+        self.data_new = create_buffer_and_store_dummy_data(self.transfersession_new.id)
+
+    def test_no_sessions_cleared(self):
+        call_command("cleanupsyncs", expiration=48)
+        assert_session_is_not_cleared(self.transfersession_old)
+        assert_session_is_not_cleared(self.transfersession_new)
+
+    def test_some_sessions_cleared(self):
+        call_command("cleanupsyncs", expiration=6)
+        assert_session_is_cleared(self.transfersession_old)
+        assert_session_is_not_cleared(self.transfersession_new)
+
+    def test_all_sessions_cleared(self):
+        call_command("cleanupsyncs", expiration=1)
+        assert_session_is_cleared(self.transfersession_old)
+        assert_session_is_cleared(self.transfersession_new)


### PR DESCRIPTION
## Summary

If sync sessions are interrupted, or time out, they may not be closed out successfully, leaving possibly large amounts of data in the buffers. This management command can be called to close out and clean up after sync sessions that are older than a certain number of hours.

## TODO

- [x] Have tests been written for the new code?