### PR TITLE
Morango 0.6.1 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 List of the most important changes for each release.
 
+## 0.6.1
+
+- Fix to set counters on `TransferSession` *after* serialization
+- Fix capabilities request header as it should be prefixed with `HTTP`
+- Fix issues with flow of transfer operations
+- Logging and error handling improvements
+
+
 ## 0.6.0
 
 - Track the `TransferSession` that last modified a `Store` record

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/morango/api/viewsets.py
+++ b/morango/api/viewsets.py
@@ -440,7 +440,10 @@ class TransferSessionViewSet(
             )
             # raise an error for synchronous, if status is false
             if result == transfer_statuses.ERRORED:
-                raise RuntimeError("Cleanup failed")
+                if context.error:
+                    raise context.error
+                else:
+                    raise RuntimeError("Cleanup failed")
 
     def get_queryset(self):
         return TransferSession.objects.filter(active=True)

--- a/morango/sync/context.py
+++ b/morango/sync/context.py
@@ -52,7 +52,7 @@ class SessionContext(object):
         if self.transfer_session:
             self.sync_session = transfer_session.sync_session or self.sync_session
             self.is_push = transfer_session.push or self.is_push
-            if transfer_session.filter and transfer_session.filter is not None:
+            if transfer_session.filter:
                 self.filter = transfer_session.get_filter()
 
     def update(
@@ -101,7 +101,7 @@ class SessionContext(object):
         if transfer_session:
             self.sync_session = transfer_session.sync_session
             self.is_push = transfer_session.push
-            if transfer_session.filter and transfer_session.filter is not None:
+            if transfer_session.filter:
                 self.filter = transfer_session.get_filter()
 
     @property

--- a/morango/sync/context.py
+++ b/morango/sync/context.py
@@ -51,8 +51,9 @@ class SessionContext(object):
 
         if self.transfer_session:
             self.sync_session = transfer_session.sync_session or self.sync_session
-            self.filter = transfer_session.get_filter() or self.filter
             self.is_push = transfer_session.push or self.is_push
+            if transfer_session.filter and transfer_session.filter is not None:
+                self.filter = transfer_session.get_filter()
 
     def update(
         self,
@@ -99,8 +100,9 @@ class SessionContext(object):
         # if transfer session was passed in, that takes precedence
         if transfer_session:
             self.sync_session = transfer_session.sync_session
-            self.filter = transfer_session.get_filter() or self.filter
             self.is_push = transfer_session.push
+            if transfer_session.filter and transfer_session.filter is not None:
+                self.filter = transfer_session.get_filter()
 
     @property
     def is_pull(self):

--- a/morango/sync/controller.py
+++ b/morango/sync/controller.py
@@ -242,7 +242,7 @@ class SessionController(object):
             return result
         except Exception as e:
             # always log the error itself
-            logging.error(e)
+            logger.error(e)
             context.update(stage_status=transfer_statuses.ERRORED, error=e)
             # fire completed signal, after context update. handlers can use context to detect error
             signal.completed.fire(context=context)

--- a/morango/sync/operations.py
+++ b/morango/sync/operations.py
@@ -693,7 +693,7 @@ class ProducerQueueOperation(LocalOperation):
             transfer_session=context.transfer_session
         ).count()
 
-        logger.info("[morango] Queued {} records".format(records_total))
+        logger.debug("[morango] Queued {} records".format(records_total))
         context.transfer_session.records_total = records_total
         context.transfer_session.save()
         return transfer_statuses.COMPLETED

--- a/morango/sync/operations.py
+++ b/morango/sync/operations.py
@@ -527,24 +527,31 @@ class BaseOperation(object):
         """
         :type context: morango.sync.controller.SessionContext
         """
+        debug_msg = "[morango:{}] {} -> {}".format(
+            "pull" if context.is_pull else "push",
+            context.__class__.__name__,
+            self.__class__.__name__
+        )
+        result = False
         try:
             # verify context object matches what the operation expects
-            result = False
             if self.expects_context is None or isinstance(
                 context, self.expects_context
             ):
+                logger.debug("{} = ?".format(debug_msg))
                 result = self.handle(context)
 
             if result is not False and result not in transfer_statuses.ALL:
                 raise NotImplementedError(
                     "Transfer operation must return False, or a transfer status"
                 )
-            return result
         except AssertionError:
             # if the operation raises an AssertionError, we equate that to returning False, which
             # means that this operation did not handle it and so other operation instances should
             # be tried to handle it
-            return False
+            result = False
+        logger.debug("{} = {}".format(debug_msg, result))
+        return result
 
     def handle(self, context):
         """
@@ -594,11 +601,9 @@ class InitializeOperation(LocalOperation):
                 start_timestamp=timezone.now(),
                 last_activity_timestamp=timezone.now(),
                 active=True,
+                transfer_stage=transfer_stages.INITIALIZING,
             )
-            fsic = json.dumps(
-                DatabaseMaxCounter.calculate_filter_max_counters(context.filter)
-            )
-            # if in request context,
+            # if in server context, we'll have request
             if context.request:
                 data.update(
                     id=context.request.data.get("id"),
@@ -606,16 +611,8 @@ class InitializeOperation(LocalOperation):
                     if context.is_push
                     else None,
                     client_fsic=context.request.data.get("client_fsic") or "{}",
-                    server_fsic=fsic,
                 )
-            elif not context.is_server:
-                data.update(
-                    client_fsic=fsic,
-                    # server_fsic is set after remote initialization, as that should hit the
-                    # previous if-block, and this `client_fsic` should end up in the request
-                    # above too
-                )
-            else:
+            elif context.is_server:
                 raise MorangoResumeSyncError(
                     "Cannot create transfer session without request as server"
                 )
@@ -651,6 +648,14 @@ class ProducerSerializeOperation(LocalOperation):
                 filter=context.filter,
             )
 
+        fsic = json.dumps(
+            DatabaseMaxCounter.calculate_filter_max_counters(context.filter)
+        )
+        if context.is_server:
+            context.transfer_session.server_fsic = fsic
+        else:
+            context.transfer_session.client_fsic = fsic
+        context.transfer_session.save()
         return transfer_statuses.COMPLETED
 
 
@@ -664,6 +669,7 @@ class ReceiverSerializeOperation(LocalOperation):
         :type context: LocalSessionContext
         """
         assert context.is_receiver
+        # TODO: move updating fsic from request to here instead of viewset serializer
         return transfer_statuses.COMPLETED
 
 
@@ -687,6 +693,7 @@ class ProducerQueueOperation(LocalOperation):
             transfer_session=context.transfer_session
         ).count()
 
+        logger.info("[morango] Queued {} records".format(records_total))
         context.transfer_session.records_total = records_total
         context.transfer_session.save()
         return transfer_statuses.COMPLETED
@@ -702,6 +709,7 @@ class ReceiverQueueOperation(LocalOperation):
         :type context: LocalSessionContext
         """
         assert context.is_receiver
+        # TODO: move updating record counts from request to here instead of viewset serializer
         return transfer_statuses.COMPLETED
 
 
@@ -740,11 +748,13 @@ class PushReceiverOperation(LocalOperation):
         assert context.is_receiver
         assert context.request is not None
 
-        data = context.request.data
-        if not isinstance(context.request.data, list):
-            data = [context.request.data]
+        # operation can be invoked even though there's nothing to transfer
+        if context.transfer_session.records_total > 0:
+            data = context.request.data
+            if not isinstance(context.request.data, list):
+                data = [context.request.data]
 
-        validate_and_create_buffer_data(data, context.transfer_session)
+            validate_and_create_buffer_data(data, context.transfer_session)
 
         if (
             context.transfer_session.records_transferred
@@ -950,13 +960,14 @@ class NetworkOperation(BaseOperation):
             )
         return data
 
-    def remote_proceed_to(self, context, stage):
+    def remote_proceed_to(self, context, stage, **kwargs):
         """
         Uses server API's to push updates to a remote `TransferSession`, which triggers the
         controller's `.proceed_to()` for the stage
 
         :type context: NetworkSessionContext
         :param stage: A transfer_stage.*
+        :param kwargs: Other kwargs to send
         :return: A tuple of the remote's status, and the server response JSON
         """
         stage = transfer_stages.stage(stage)
@@ -966,14 +977,15 @@ class NetworkOperation(BaseOperation):
 
         if remote_stage < stage:
             # if current stage is not yet at `stage`, push it to that stage through update
-            data = self.update_transfer_session(context, transfer_stage=stage)
+            kwargs.update(transfer_stage=stage)
+            data = self.update_transfer_session(context, **kwargs)
             remote_status = data.get("transfer_stage_status")
         elif remote_stage > stage:
             # if past this stage, then we just make sure returned status is completed
             remote_status = transfer_statuses.COMPLETED
 
         if not remote_status:
-            raise MorangoResumeSyncError("Error")
+            raise MorangoResumeSyncError("Remote failed to proceed to {}".format(stage))
 
         # if still in progress, then we return PENDING which will cause controller
         # to again call the middleware that contains this operation, and check the server status
@@ -1027,7 +1039,7 @@ class NetworkInitializeOperation(NetworkOperation):
         assert ASYNC_OPERATIONS in context.capabilities
 
         # if local stage is transferring or beyond, we definitely don't need to initialize
-        if transfer_stages.stage(context.stage) < transfer_stages.stage(
+        if context.stage is not None and transfer_stages.stage(context.stage) < transfer_stages.stage(
             transfer_stages.TRANSFERRING
         ):
             self.create_transfer_session(context)
@@ -1069,12 +1081,16 @@ class NetworkSerializeOperation(NetworkOperation):
         assert context.transfer_session is not None
         assert ASYNC_OPERATIONS in context.capabilities
 
+        update_kwargs = {}
+        if context.is_push:
+            update_kwargs.update(client_fsic=context.transfer_session.client_fsic)
+
         remote_status, data = self.remote_proceed_to(
-            context, transfer_stages.SERIALIZING
+            context, transfer_stages.SERIALIZING, **update_kwargs
         )
 
-        if remote_status == transfer_statuses.COMPLETED:
-            context.transfer_session.server_fsic = data.get("server_fsic") or "{}"
+        if context.is_pull and remote_status == transfer_statuses.COMPLETED:
+            context.transfer_session.server_fsic = data.get("server_fsic")
             context.transfer_session.save()
 
         return remote_status
@@ -1100,9 +1116,15 @@ class NetworkQueueOperation(NetworkOperation):
         assert context.transfer_session is not None
         assert ASYNC_OPERATIONS in context.capabilities
 
-        remote_status, data = self.remote_proceed_to(context, transfer_stages.QUEUING)
+        update_kwargs = {}
+        if context.is_push:
+            update_kwargs.update(records_total=context.transfer_session.records_total)
 
-        if remote_status == transfer_statuses.COMPLETED:
+        remote_status, data = self.remote_proceed_to(
+            context, transfer_stages.QUEUING, **update_kwargs
+        )
+
+        if context.is_pull and remote_status == transfer_statuses.COMPLETED:
             context.transfer_session.records_total = data.get("records_total", 0)
             context.transfer_session.save()
 
@@ -1117,6 +1139,10 @@ class NetworkPushTransferOperation(NetworkOperation):
         assert context.transfer_session is not None
         assert context.is_push
 
+        if context.transfer_session.records_total == 0:
+            # since we won't be transferring anything, we can say we're done
+            return transfer_statuses.COMPLETED
+
         offset = context.transfer_session.records_transferred
         chunk_size = context.connection.chunk_size
 
@@ -1129,8 +1155,7 @@ class NetworkPushTransferOperation(NetworkOperation):
         ).data
 
         # push buffers chunk to server
-        if len(data) > 0:
-            self.put_buffers(context, data)
+        self.put_buffers(context, data)
 
         context.transfer_session.records_transferred = min(
             offset + chunk_size, context.transfer_session.records_total
@@ -1158,20 +1183,19 @@ class NetworkPullTransferOperation(NetworkOperation):
         assert context.transfer_session is not None
         assert context.is_pull
 
-        # grab buffers chunk
-        data = self.get_buffers(context)
         transfer_session = context.transfer_session
 
-        validate_and_create_buffer_data(
-            data, transfer_session, connection=context.connection
-        )
+        if transfer_session.records_total > 0:
+            # grab buffers, just one chunk
+            data = self.get_buffers(context)
+
+            validate_and_create_buffer_data(
+                data, transfer_session, connection=context.connection
+            )
 
         # if we've transferred all records, return a completed status
         op_status = transfer_statuses.PENDING
-        if (
-            context.transfer_session.records_transferred
-            >= context.transfer_session.records_total
-        ):
+        if transfer_session.records_transferred >= transfer_session.records_total:
             op_status = transfer_statuses.COMPLETED
 
         # update the records transferred so client and server are in agreement

--- a/morango/sync/utils.py
+++ b/morango/sync/utils.py
@@ -91,11 +91,9 @@ def validate_and_create_buffer_data(  # noqa: C901
         )
         if expected_model_uuid != record["model_uuid"]:
             raise ValidationError(
-                {
-                    "model_uuid": "Does not match results of calling {}.compute_namespaced_id".format(
-                        Model.__class__.__name__
-                    )
-                }
+                "Does not match results of calling {}.compute_namespaced_id".format(
+                    Model.__class__.__name__
+                )
             )
 
         # ensure the profile is marked onto the buffer record
@@ -104,30 +102,24 @@ def validate_and_create_buffer_data(  # noqa: C901
         # ensure the partition is within the transfer session's filter
         if not transfer_session.get_filter().contains_partition(record["partition"]):
             raise ValidationError(
-                {
-                    "partition": "Partition {} is not contained within filter for TransferSession ({})".format(
-                        record["partition"], transfer_session.filter
-                    )
-                }
+                "Partition {} is not contained within filter for TransferSession ({})".format(
+                    record["partition"], transfer_session.filter
+                )
             )
 
         # ensure that all nested RMCB models are properly associated with this record and transfer session
         for rmcb in record.pop("rmcb_list"):
             if rmcb["transfer_session"] != transfer_session.id:
                 raise ValidationError(
-                    {
-                        "rmcb_list": "Transfer session on RMCB ({}) does not match Buffer's TransferSession ({})".format(
-                            rmcb["transfer_session"], transfer_session
-                        )
-                    }
+                    "Transfer session on RMCB ({}) does not match Buffer's TransferSession ({})".format(
+                        rmcb["transfer_session"], transfer_session
+                    )
                 )
             if rmcb["model_uuid"] != record["model_uuid"]:
                 raise ValidationError(
-                    {
-                        "rmcb_list": "Model UUID on RMCB ({}) does not match Buffer's Model UUID ({})".format(
-                            rmcb["model_uuid"], record["model_uuid"]
-                        )
-                    }
+                    "Model UUID on RMCB ({}) does not match Buffer's Model UUID ({})".format(
+                        rmcb["model_uuid"], record["model_uuid"]
+                    )
                 )
             rmcb["transfer_session_id"] = rmcb.pop("transfer_session")
             rmcb_list += [RecordMaxCounterBuffer(**rmcb)]

--- a/morango/utils.py
+++ b/morango/utils.py
@@ -46,7 +46,7 @@ def get_capabilities():
 
 CAPABILITIES = get_capabilities()
 CAPABILITIES_CLIENT_HEADER = "X-Morango-Capabilities"
-CAPABILITIES_SERVER_HEADER = CAPABILITIES_CLIENT_HEADER.upper().replace("-", "_")
+CAPABILITIES_SERVER_HEADER = "HTTP_{}".format(CAPABILITIES_CLIENT_HEADER.upper().replace("-", "_"))
 
 
 def serialize_capabilities_to_client_request(request):

--- a/tests/testapp/tests/integration/test_syncsession.py
+++ b/tests/testapp/tests/integration/test_syncsession.py
@@ -154,7 +154,6 @@ class PushPullClientTestCase(LiveServerTestCase):
         for _ in range(5):
             SummaryLog.objects.create(user=self.local_user)
             InteractionLog.objects.create(user=self.local_user)
-        self.profile_controller.serialize_into_store(self.filter)
 
         with second_environment():
             self.assertEqual(
@@ -199,7 +198,6 @@ class PushPullClientTestCase(LiveServerTestCase):
             for _ in range(5):
                 SummaryLog.objects.create(user=self.remote_user)
                 InteractionLog.objects.create(user=self.remote_user)
-            self.profile_controller.serialize_into_store(self.filter)
 
         self.assertEqual(0, SummaryLog.objects.filter(user=self.local_user).count())
         self.assertEqual(0, InteractionLog.objects.filter(user=self.local_user).count())
@@ -234,7 +232,6 @@ class PushPullClientTestCase(LiveServerTestCase):
         for _ in range(5):
             SummaryLog.objects.create(user=self.local_user)
             InteractionLog.objects.create(user=self.local_user)
-        self.profile_controller.serialize_into_store(self.filter)
 
         with second_environment():
             self.assertEqual(0, SummaryLog.objects.filter(user=self.remote_user).count())

--- a/tests/testapp/tests/test_api.py
+++ b/tests/testapp/tests/test_api.py
@@ -858,6 +858,9 @@ class BufferEndpointTestCase(CertificateTestCaseMixin, APITestCase):
 
         server_cert = kwargs["transfer_session"].sync_session.client_certificate
         push = kwargs["transfer_session"].push
+        records_total = kwargs["transfer_session"].records_total or 0
+        kwargs["transfer_session"].records_total = records_total + 1
+        kwargs["transfer_session"].save()
 
         filt = (
             server_cert.get_scope().write_filter

--- a/tests/testapp/tests/test_utils.py
+++ b/tests/testapp/tests/test_utils.py
@@ -10,6 +10,7 @@ from morango.constants.capabilities import ASYNC_OPERATIONS
 from morango.constants import transfer_stages
 from morango.utils import SETTINGS
 from morango.utils import CAPABILITIES_CLIENT_HEADER
+from morango.utils import CAPABILITIES_SERVER_HEADER
 from morango.utils import get_capabilities
 from morango.utils import serialize_capabilities_to_client_request
 from morango.utils import parse_capabilities_from_server_request
@@ -67,7 +68,7 @@ class CapabilitiesTestCase(SimpleTestCase):
 
     def test_parse(self):
         req = HttpRequest()
-        req.META.update(X_MORANGO_CAPABILITIES="TEST PARSE")
+        req.META.update(HTTP_X_MORANGO_CAPABILITIES="TEST PARSE")
         result = parse_capabilities_from_server_request(req)
         self.assertEqual({"PARSE", "TEST"}, result)
 


### PR DESCRIPTION
## Summary
- Don't boolean compare against `get_filter()` as it always returns a `Filter` object
- Raise error in viewset cleanup if set on context for better insights
- Debug logging to track invocation and results of operations
- Set counters on `TransferSession` after serialization
- Fix capabilities header as it should be prefixed with `HTTP`
- Fix issues with flow of operations

## TODO

- [X] Have tests been written for the new code?

## Reviewer guidance
From Kolibri, testing with `INTEGRATION_TEST=1 pytest -x kolibri/core/auth/test/test_morango_integration.py ` was helpful
