### PR TITLE
Fix handling of sleep for `proceed_to_and_wait_for`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 List of the most important changes for each release.
 
+## 0.6.2
+
+- Fixes slow performance due to excessive use of `sleep`
+
 ## 0.6.1
 
 - Fix to set counters on `TransferSession` *after* serialization

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/morango/api/viewsets.py
+++ b/morango/api/viewsets.py
@@ -382,7 +382,9 @@ class TransferSessionViewSet(
             if self.async_allowed()
             else transfer_stages.QUEUING
         )
-        result = session_controller.proceed_to_and_wait_for(to_stage, context=context)
+        result = session_controller.proceed_to_and_wait_for(
+            to_stage, context=context, max_interval=2
+        )
 
         if result == transfer_statuses.ERRORED:
             if context.error:
@@ -422,7 +424,7 @@ class TransferSessionViewSet(
                 session_controller.proceed_to(update_stage, context=context)
             else:
                 session_controller.proceed_to_and_wait_for(
-                    update_stage, context=context
+                    update_stage, context=context, max_interval=2
                 )
 
         return super(TransferSessionViewSet, self).update(request, *args, **kwargs)
@@ -436,7 +438,7 @@ class TransferSessionViewSet(
             session_controller.proceed_to(transfer_stages.CLEANUP, context=context)
         else:
             result = session_controller.proceed_to_and_wait_for(
-                transfer_stages.CLEANUP, context=context
+                transfer_stages.CLEANUP, context=context, max_interval=2
             )
             # raise an error for synchronous, if status is false
             if result == transfer_statuses.ERRORED:

--- a/morango/sync/syncsession.py
+++ b/morango/sync/syncsession.py
@@ -606,7 +606,8 @@ class TransferClient(object):
             contexts = reversed(contexts)
 
         for context in contexts:
-            result = self.controller.proceed_to_and_wait_for(stage, context=context)
+            max_interval = 1 if context is self.local_context else 5
+            result = self.controller.proceed_to_and_wait_for(stage, context=context, max_interval=max_interval)
             if result == transfer_statuses.ERRORED:
                 raise_from(
                     MorangoError("Stage `{}` failed".format(stage)),
@@ -623,7 +624,7 @@ class TransferClient(object):
 
         # initialize the transfer session locally
         status = self.controller.proceed_to_and_wait_for(
-            transfer_stages.INITIALIZING, context=self.local_context
+            transfer_stages.INITIALIZING, context=self.local_context, max_interval=1
         )
         if status == transfer_statuses.ERRORED:
             raise_from(

--- a/tests/testapp/tests/sync/test_controller.py
+++ b/tests/testapp/tests/sync/test_controller.py
@@ -713,7 +713,7 @@ class SessionControllerTestCase(SimpleTestCase):
                 transfer_statuses.PENDING,
                 transfer_statuses.COMPLETED
             ]
-            result = self.controller.proceed_to_and_wait_for(transfer_stages.CLEANUP, interval=0.1)
+            result = self.controller.proceed_to_and_wait_for(transfer_stages.CLEANUP, max_interval=0.1)
             self.assertEqual(result, transfer_statuses.COMPLETED)
 
     def test_proceed_to_and_wait_for__errored(self):
@@ -722,7 +722,7 @@ class SessionControllerTestCase(SimpleTestCase):
                 transfer_statuses.PENDING,
                 transfer_statuses.ERRORED
             ]
-            result = self.controller.proceed_to_and_wait_for(transfer_stages.CLEANUP, interval=0.1)
+            result = self.controller.proceed_to_and_wait_for(transfer_stages.CLEANUP, max_interval=0.1)
             self.assertEqual(result, transfer_statuses.ERRORED)
 
     def test_invoke_middleware(self):

--- a/tests/testapp/tests/sync/test_syncsession.py
+++ b/tests/testapp/tests/sync/test_syncsession.py
@@ -382,7 +382,7 @@ class TransferClientTestCase(BaseTransferClientTestCase):
         with self.assertRaises(MorangoError):
             self.client.proceed_to_and_wait_for(transfer_stages.QUEUING)
         self.controller.proceed_to_and_wait_for.assert_called_once_with(
-            transfer_stages.QUEUING, context=self.client.remote_context
+            transfer_stages.QUEUING, context=self.client.remote_context, max_interval=5
         )
 
     @mock.patch("morango.sync.syncsession.TransferClient.proceed_to_and_wait_for")
@@ -398,7 +398,7 @@ class TransferClientTestCase(BaseTransferClientTestCase):
         self.assertEqual(sync_filter, self.client.local_context.filter)
         self.assertEqual(sync_filter, self.client.remote_context.filter)
         self.controller.proceed_to_and_wait_for.assert_any_call(
-            transfer_stages.INITIALIZING, context=self.client.local_context
+            transfer_stages.INITIALIZING, context=self.client.local_context, max_interval=1
         )
         self.assertEqual(self.transfer_session, self.client.remote_context.transfer_session)
         session_started_handler.assert_called_once_with(transfer_session=self.transfer_session)


### PR DESCRIPTION
## Summary
I forgot to circle back around to ensuring the sleeping interval between checks on an operation's status is optimal. The result was that we were sleeping a lot, too much, and it slowed down syncing quite a bit.

### Profiling screenshots
| Before | After |
| --- | ---
| ![Screenshot from 2021-07-26 16-14-01](https://user-images.githubusercontent.com/819838/127073605-b79e65c1-0cd3-4a48-89e4-c20470c15f0c.png) | ![Screenshot from 2021-07-26 16-44-51](https://user-images.githubusercontent.com/819838/127073657-91f3b6cd-8595-4605-a4cc-fddcd497f640.png) |

## TODO

- [X] Have tests been written for the new code?

## Reviewer guidance
You probably can't tell from the tests that it will be faster.

