### PR TITLE
Fix counter handling causing repeated syncs of same data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 List of the most important changes for each release.
 
+## 0.6.3
+
+- Fixes issue handling database counters which caused repeat syncing of unchanged data
+
 ## 0.6.2
 
 - Fixes slow performance due to excessive use of `sleep`

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/morango/constants/settings.py
+++ b/morango/constants/settings.py
@@ -8,8 +8,7 @@ MORANGO_INITIALIZE_OPERATIONS = (
     "morango.sync.operations:NetworkInitializeOperation",
 )
 MORANGO_SERIALIZE_OPERATIONS = (
-    "morango.sync.operations:ProducerSerializeOperation",
-    "morango.sync.operations:ReceiverSerializeOperation",
+    "morango.sync.operations:SerializeOperation",
     "morango.sync.operations:LegacyNetworkSerializeOperation",
     "morango.sync.operations:NetworkSerializeOperation",
 )

--- a/morango/sync/syncsession.py
+++ b/morango/sync/syncsession.py
@@ -600,14 +600,12 @@ class TransferClient(object):
         )
 
     def proceed_to_and_wait_for(self, stage):
-        contexts = (self.remote_context, self.local_context)
-        if self.local_context.is_push:
-            # reverse contexts if a push to operate on local first
-            contexts = reversed(contexts)
-
+        contexts = (self.local_context, self.remote_context)
         for context in contexts:
             max_interval = 1 if context is self.local_context else 5
-            result = self.controller.proceed_to_and_wait_for(stage, context=context, max_interval=max_interval)
+            result = self.controller.proceed_to_and_wait_for(
+                stage, context=context, max_interval=max_interval
+            )
             if result == transfer_statuses.ERRORED:
                 raise_from(
                     MorangoError("Stage `{}` failed".format(stage)),

--- a/tests/testapp/tests/sync/test_syncsession.py
+++ b/tests/testapp/tests/sync/test_syncsession.py
@@ -371,9 +371,9 @@ class TransferClientTestCase(BaseTransferClientTestCase):
         mock_proceed_calls = mock_proceed.call_args_list
         self.assertEqual(2, len(mock_proceed_calls))
         self.assertEqual(transfer_stages.QUEUING, mock_proceed_calls[0][0][0])
-        self.assertEqual(self.client.remote_context, mock_proceed_calls[0][1].get("context"))
+        self.assertEqual(self.client.local_context, mock_proceed_calls[0][1].get("context"))
         self.assertEqual(transfer_stages.QUEUING, mock_proceed_calls[1][0][0])
-        self.assertEqual(self.client.local_context, mock_proceed_calls[1][1].get("context"))
+        self.assertEqual(self.client.remote_context, mock_proceed_calls[1][1].get("context"))
 
     def test_proceed_to_and_wait_for__error(self):
         self.client.local_context.is_push = False
@@ -382,7 +382,7 @@ class TransferClientTestCase(BaseTransferClientTestCase):
         with self.assertRaises(MorangoError):
             self.client.proceed_to_and_wait_for(transfer_stages.QUEUING)
         self.controller.proceed_to_and_wait_for.assert_called_once_with(
-            transfer_stages.QUEUING, context=self.client.remote_context, max_interval=5
+            transfer_stages.QUEUING, context=self.client.local_context, max_interval=1
         )
 
     @mock.patch("morango.sync.syncsession.TransferClient.proceed_to_and_wait_for")

--- a/tests/testapp/tests/test_utils.py
+++ b/tests/testapp/tests/test_utils.py
@@ -30,7 +30,7 @@ class SettingsTestCase(SimpleTestCase):
         self.assertEqual(SETTINGS.MORANGO_DESERIALIZE_AFTER_DEQUEUING, True)
         self.assertEqual(SETTINGS.MORANGO_DISALLOW_ASYNC_OPERATIONS, False)
         self.assertLength(3, SETTINGS.MORANGO_INITIALIZE_OPERATIONS)
-        self.assertLength(4, SETTINGS.MORANGO_SERIALIZE_OPERATIONS)
+        self.assertLength(3, SETTINGS.MORANGO_SERIALIZE_OPERATIONS)
         self.assertLength(4, SETTINGS.MORANGO_QUEUE_OPERATIONS)
         self.assertLength(4, SETTINGS.MORANGO_DEQUEUE_OPERATIONS)
         self.assertLength(4, SETTINGS.MORANGO_DESERIALIZE_OPERATIONS)


### PR DESCRIPTION
## Summary
- When data remains unchanged, Morango was repeatedly syncing the same data which should not happen
- The issue was hard to pinpoint but was centered around order of operations regarding how we handle the counters for client/server which get set on the `TransferSession` and used for queuing data
- Key points are:
  - Always operate on local context before operating on network context
  - Always exchange counters during serialization stage
  - Only update local counters when the receiver

## TODO

- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance
1. Run a push and pull sync on a brand new instance with a server that has data
2. Repeat the sync without any data changes and ensure nothing is pulled

