### PR TITLE
Replace assert statements to avoid removal with python -O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 List of the most important changes for each release.
 
+## 0.6.4
+- Fixes issue with `assert` statement removal during python optimization
+
 ## 0.6.3
 
 - Fixes issue handling database counters which caused repeat syncing of unchanged data

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.3"
+__version__ = "0.6.4"

--- a/morango/api/permissions.py
+++ b/morango/api/permissions.py
@@ -33,7 +33,7 @@ class BasicMultiArgumentAuthentication(authentication.BasicAuthentication):
                 credentials[key] = val
 
         # authenticate the user via Django's auth backends
-        user = authenticate(**credentials)
+        user = authenticate(request=request, **credentials)
 
         if user is None:
             raise exceptions.AuthenticationFailed("Invalid credentials.")

--- a/morango/api/viewsets.py
+++ b/morango/api/viewsets.py
@@ -31,6 +31,7 @@ from morango.models.fields.crypto import SharedKey
 from morango.sync.context import LocalSessionContext
 from morango.sync.controller import SessionController
 from morango.utils import CAPABILITIES
+from morango.utils import _assert
 from morango.utils import parse_capabilities_from_server_request
 
 
@@ -43,7 +44,7 @@ else:
 
 
 def controller_signal_logger(context=None):
-    assert context is not None
+    _assert(context is not None, "Missing context")
 
     if context.stage_status == transfer_statuses.PENDING:
         logging.info("Starting stage '{}'".format(context.stage))

--- a/morango/models/certificates.py
+++ b/morango/models/certificates.py
@@ -27,6 +27,7 @@ from morango.errors import CertificateScopeNotSubset
 from morango.errors import CertificateSignatureInvalid
 from morango.errors import NonceDoesNotExist
 from morango.errors import NonceExpired
+from morango.utils import _assert
 
 
 @python_2_unicode_compatible
@@ -87,9 +88,10 @@ class Certificate(mptt.models.MPTTModel, UUIDModelMixin):
         cert.scope_version = scope_def.version
         cert.profile = scope_def.profile
         primary_scope_param_key = scope_def.primary_scope_param_key
-        assert (
-            primary_scope_param_key
-        ), "Root cert can only be created for ScopeDefinition that has primary_scope_param_key defined"
+        _assert(
+            primary_scope_param_key,
+            "Root cert can only be created for ScopeDefinition that has primary_scope_param_key defined",
+        )
 
         # generate a key and extract the public key component
         cert.private_key = Key()
@@ -207,11 +209,11 @@ class Certificate(mptt.models.MPTTModel, UUIDModelMixin):
         cert = cls.deserialize(cert_data["serialized"], cert_data["signature"])
 
         # verify the id of the cert matches the id of the outer serialized data
-        assert cert_data["id"] == cert.id
+        _assert(cert_data["id"] == cert.id, "Serialized ID does not match")
 
         # check that the expected ID matches, if specified
         if expected_last_id:
-            assert cert.id == expected_last_id
+            _assert(cert.id == expected_last_id, "ID does not match expected value")
 
         # if cert already exists locally, it's already been verified, so no need to continue
         # (this also means we have the full cert chain for it, given the `parent` relations)
@@ -224,9 +226,10 @@ class Certificate(mptt.models.MPTTModel, UUIDModelMixin):
         if len(cert_chain) > 1:
             cls.save_certificate_chain(cert_chain[:-1], expected_last_id=cert.parent_id)
         else:
-            assert (
-                not cert.parent_id
-            ), "First cert in chain must be a root cert (no parent)"
+            _assert(
+                not cert.parent_id,
+                "First cert in chain must be a root cert (no parent)",
+            )
 
         # ensure the certificate checks out (now that we know its parent, if any, is saved)
         cert.check_certificate()
@@ -237,9 +240,9 @@ class Certificate(mptt.models.MPTTModel, UUIDModelMixin):
         return cert
 
     def sign(self, value):
-        assert (
-            self.private_key
-        ), "Can only sign using certificates that have private keys"
+        _assert(
+            self.private_key, "Can only sign using certificates that have private keys"
+        )
         return self.private_key.sign(value)
 
     def verify(self, value, signature):

--- a/morango/models/core.py
+++ b/morango/models/core.py
@@ -318,7 +318,9 @@ class TransferSession(models.Model):
             )
 
     def get_touched_record_ids_for_model(self, model):
-        if isinstance(model, SyncableModel) or issubclass(model, SyncableModel):
+        if isinstance(model, SyncableModel) or (
+            isinstance(model, six.class_types) and issubclass(model, SyncableModel)
+        ):
             model = model.morango_model_name
         _assert(isinstance(model, six.string_types), "Model must resolve to string")
         return Store.objects.filter(

--- a/morango/models/core.py
+++ b/morango/models/core.py
@@ -33,6 +33,7 @@ from morango.models.utils import get_0_5_system_id
 from morango.models.utils import get_0_5_mac_address
 from morango.constants import transfer_stages
 from morango.constants import transfer_statuses
+from morango.utils import _assert
 
 logger = logging.getLogger(__name__)
 
@@ -317,9 +318,9 @@ class TransferSession(models.Model):
             )
 
     def get_touched_record_ids_for_model(self, model):
-        if isinstance(model, SyncableModel):
+        if isinstance(model, SyncableModel) or issubclass(model, SyncableModel):
             model = model.morango_model_name
-        assert isinstance(model, six.string_types)
+        _assert(isinstance(model, six.string_types), "Model must resolve to string")
         return Store.objects.filter(
             model_name=model, last_transfer_session_id=self.id
         ).values_list("id", flat=True)
@@ -643,11 +644,13 @@ class SyncableModel(UUIDModelMixin):
         self, using=None, keep_parents=False, hard_delete=False, *args, **kwargs
     ):
         using = using or router.db_for_write(self.__class__, instance=self)
-        assert (
-            self._get_pk_val() is not None
-        ), "%s object can't be deleted because its %s attribute is set to None." % (
-            self._meta.object_name,
-            self._meta.pk.attname,
+        _assert(
+            self._get_pk_val() is not None,
+            "%s object can't be deleted because its %s attribute is set to None."
+            % (
+                self._meta.object_name,
+                self._meta.pk.attname,
+            ),
         )
         collector = Collector(using=using)
         collector.collect([self], keep_parents=keep_parents)

--- a/morango/models/fields/uuids.py
+++ b/morango/models/fields/uuids.py
@@ -2,6 +2,7 @@ import hashlib
 import uuid
 
 from django.db import models
+from morango.utils import _assert
 
 
 def sha2_uuid(*args):
@@ -96,9 +97,10 @@ class UUIDModelMixin(models.Model):
             return uuid.uuid4().hex
 
         # if we got this far, uuid_input_fields should be a tuple
-        assert isinstance(
-            self.uuid_input_fields, tuple
-        ), "'uuid_input_fields' must either be a tuple or the string 'RANDOM'"
+        _assert(
+            isinstance(self.uuid_input_fields, tuple),
+            "'uuid_input_fields' must either be a tuple or the string 'RANDOM'",
+        )
 
         # calculate the input to the UUID function
         hashable_input_vals = []

--- a/morango/sync/controller.py
+++ b/morango/sync/controller.py
@@ -9,6 +9,7 @@ from morango.sync.operations import _deserialize_from_store
 from morango.sync.operations import _serialize_into_store
 from morango.sync.operations import OperationLogger
 from morango.sync.utils import SyncSignalGroup
+from morango.utils import _assert
 
 
 logger = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ def _self_referential_fk(klass_model):
 
 class MorangoProfileController(object):
     def __init__(self, profile):
-        assert profile, "profile needs to be defined."
+        _assert(profile, "profile needs to be defined.")
         self.profile = profile
 
     def serialize_into_store(self, filter=None):
@@ -50,6 +51,7 @@ class MorangoProfileController(object):
 
     def create_network_connection(self, base_url, **kwargs):
         from morango.sync.syncsession import NetworkSyncConnection
+
         kwargs.update(base_url=base_url)
         return NetworkSyncConnection(**kwargs)
 

--- a/morango/utils.py
+++ b/morango/utils.py
@@ -46,7 +46,9 @@ def get_capabilities():
 
 CAPABILITIES = get_capabilities()
 CAPABILITIES_CLIENT_HEADER = "X-Morango-Capabilities"
-CAPABILITIES_SERVER_HEADER = "HTTP_{}".format(CAPABILITIES_CLIENT_HEADER.upper().replace("-", "_"))
+CAPABILITIES_SERVER_HEADER = "HTTP_{}".format(
+    CAPABILITIES_CLIENT_HEADER.upper().replace("-", "_")
+)
 
 
 def serialize_capabilities_to_client_request(request):
@@ -99,3 +101,12 @@ if os.name == "posix":
     pid_exists = _posix_pid_exists
 else:
     pid_exists = _windows_pid_exists
+
+
+def _assert(condition, message):
+    """
+    :param condition: A bool condition that if false will raise an AssertionError
+    :param message: assertion error detail message
+    """
+    if not condition:
+        raise AssertionError(message)

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
 
 commands =
   sh -c '! tests/testapp/manage.py makemigrations --dry-run --exit --noinput'
-  py.test {posargs:--cov=morango --color=no}
+  python -O -m pytest {posargs:--cov=morango --color=no}
 
 [testenv:postgres]
 deps =
@@ -41,7 +41,7 @@ setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}/tests/testapp
   DJANGO_SETTINGS_MODULE = testapp.postgres_settings
 commands =
-  py.test {posargs:--cov=morango --color=no}
+  python -O -m pytest  {posargs:--cov=morango --color=no}
 
 [testenv:windows]
 deps =
@@ -49,4 +49,4 @@ deps =
 setenv =
     PYTHONPATH = {toxinidir}{:}{toxinidir}/tests/testapp
 commands =
-  pytest {posargs:--cov=morango --color=no} -m windows
+  python -O -m pytest {posargs:--cov=morango --color=no} -m windows


### PR DESCRIPTION
## Summary

- Python 4 android compiles `.py` files into `.pyo` by default which removes plain `assert` statements, the same behavior as `-O` flag
- Some other tweaks from Kolibri integration

## TODO

- [x] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance
- Are you able to sync Kolibri using `python -O`
