### PR TITLE
Chunk through fsics when queuing into the buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 List of the most important changes for each release.
 
+## 0.6.5
+- Sets queuing limit of 100k combined FSICs between client and server
+- Fixes SQL expression tree error when there are many FSICs, up to 100k limit
+
 ## 0.6.4
 - Fixes issue with `assert` statement removal during python optimization
 

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.4"
+__version__ = "0.6.5"

--- a/morango/errors.py
+++ b/morango/errors.py
@@ -60,3 +60,7 @@ class MorangoResumeSyncError(MorangoError):
 
 class MorangoContextUpdateError(MorangoError):
     pass
+
+
+class MorangoLimitExceeded(MorangoError):
+    pass

--- a/morango/sync/operations.py
+++ b/morango/sync/operations.py
@@ -413,7 +413,6 @@ def _queue_into_buffer(transfersession):
     We use raw sql queries to place data in the buffer and the record max counter buffer, which matches the conditions of the FSIC,
     as well as the partition for the data we are syncing.
     """
-    last_saved_by_conditions = []
     filter_prefixes = Filter(transfersession.filter)
     server_fsic = json.loads(transfersession.server_fsic)
     client_fsic = json.loads(transfersession.client_fsic)
@@ -427,18 +426,6 @@ def _queue_into_buffer(transfersession):
     if not fsics:
         return
 
-    # create condition for all push FSICs where instance_ids are equal, but internal counters are higher than FSICs counters
-    for instance, counter in six.iteritems(fsics):
-        last_saved_by_conditions += [
-            "(last_saved_instance = '{0}' AND last_saved_counter > {1})".format(
-                instance, counter
-            )
-        ]
-    if fsics:
-        last_saved_by_conditions = [
-            _join_with_logical_operator(last_saved_by_conditions, "OR")
-        ]
-
     partition_conditions = []
     # create condition for filtering by partitions
     for prefix in filter_prefixes:
@@ -446,47 +433,71 @@ def _queue_into_buffer(transfersession):
     if filter_prefixes:
         partition_conditions = [_join_with_logical_operator(partition_conditions, "OR")]
 
-    # combine conditions
-    fsic_and_partition_conditions = _join_with_logical_operator(
-        last_saved_by_conditions + partition_conditions, "AND"
-    )
+    fsics = list(fsics.items())
 
-    # filter by profile
-    where_condition = _join_with_logical_operator(
-        [
-            fsic_and_partition_conditions,
-            "profile = '{}'".format(transfersession.sync_session.profile),
-        ],
-        "AND",
-    )
-
-    # execute raw sql to take all records that match condition, to be put into buffer for transfer
+    # chunk inserts all within one cursor
     with connection.cursor() as cursor:
-        queue_buffer = """INSERT INTO {outgoing_buffer}
-                        (model_uuid, serialized, deleted, last_saved_instance, last_saved_counter, hard_deleted,
-                         model_name, profile, partition, source_id, conflicting_serialized_data, transfer_session_id, _self_ref_fk)
-                        SELECT id, serialized, deleted, last_saved_instance, last_saved_counter, hard_deleted, model_name, profile, partition, source_id, conflicting_serialized_data, '{transfer_session_id}', _self_ref_fk
-                        FROM {store} WHERE {condition}""".format(
-            outgoing_buffer=Buffer._meta.db_table,
-            transfer_session_id=transfersession.id,
-            condition=where_condition,
-            store=Store._meta.db_table,
-        )
-        cursor.execute(queue_buffer)
-        # take all record max counters that are foreign keyed onto store models, which were queued into the buffer
-        queue_rmc_buffer = """INSERT INTO {outgoing_rmcb}
-                            (instance_id, counter, transfer_session_id, model_uuid)
-                            SELECT instance_id, counter, '{transfer_session_id}', store_model_id
-                            FROM {record_max_counter} AS rmc
-                            INNER JOIN {outgoing_buffer} AS buffer ON rmc.store_model_id = buffer.model_uuid
-                            WHERE buffer.transfer_session_id = '{transfer_session_id}'
-                            """.format(
-            outgoing_rmcb=RecordMaxCounterBuffer._meta.db_table,
-            transfer_session_id=transfersession.id,
-            record_max_counter=RecordMaxCounter._meta.db_table,
-            outgoing_buffer=Buffer._meta.db_table,
-        )
-        cursor.execute(queue_rmc_buffer)
+        i = 0
+        chunk_size = 200
+        chunk = fsics[:chunk_size]
+
+        while chunk:
+            last_saved_by_conditions = []
+            # create condition for all push FSICs where instance_ids are equal, but internal counters are higher than
+            # FSICs counters
+            for instance, counter in chunk:
+                last_saved_by_conditions += [
+                    "(last_saved_instance = '{0}' AND last_saved_counter > {1})".format(
+                        instance, counter
+                    )
+                ]
+            if fsics:
+                last_saved_by_conditions = [
+                    _join_with_logical_operator(last_saved_by_conditions, "OR")
+                ]
+
+            # combine conditions
+            fsic_and_partition_conditions = _join_with_logical_operator(
+                last_saved_by_conditions + partition_conditions, "AND"
+            )
+
+            # filter by profile
+            where_condition = _join_with_logical_operator(
+                [
+                    fsic_and_partition_conditions,
+                    "profile = '{}'".format(transfersession.sync_session.profile),
+                ],
+                "AND",
+            )
+
+            # execute raw sql to take all records that match condition, to be put into buffer for transfer
+            queue_buffer = """INSERT INTO {outgoing_buffer}
+                            (model_uuid, serialized, deleted, last_saved_instance, last_saved_counter, hard_deleted,
+                             model_name, profile, partition, source_id, conflicting_serialized_data, transfer_session_id, _self_ref_fk)
+                            SELECT id, serialized, deleted, last_saved_instance, last_saved_counter, hard_deleted, model_name, profile, partition, source_id, conflicting_serialized_data, '{transfer_session_id}', _self_ref_fk
+                            FROM {store} WHERE {condition}""".format(
+                outgoing_buffer=Buffer._meta.db_table,
+                transfer_session_id=transfersession.id,
+                condition=where_condition,
+                store=Store._meta.db_table,
+            )
+            cursor.execute(queue_buffer)
+            # take all record max counters that are foreign keyed onto store models, which were queued into the buffer
+            queue_rmc_buffer = """INSERT INTO {outgoing_rmcb}
+                                (instance_id, counter, transfer_session_id, model_uuid)
+                                SELECT instance_id, counter, '{transfer_session_id}', store_model_id
+                                FROM {record_max_counter} AS rmc
+                                INNER JOIN {outgoing_buffer} AS buffer ON rmc.store_model_id = buffer.model_uuid
+                                WHERE buffer.transfer_session_id = '{transfer_session_id}'
+                                """.format(
+                outgoing_rmcb=RecordMaxCounterBuffer._meta.db_table,
+                transfer_session_id=transfersession.id,
+                record_max_counter=RecordMaxCounter._meta.db_table,
+                outgoing_buffer=Buffer._meta.db_table,
+            )
+            cursor.execute(queue_rmc_buffer)
+            i += chunk_size
+            chunk = fsics[i : i + chunk_size]
 
 
 @transaction.atomic(using=USING_DB)

--- a/morango/sync/operations.py
+++ b/morango/sync/operations.py
@@ -426,6 +426,7 @@ def _queue_into_buffer(transfersession):
     if not fsics:
         return
 
+    profile_condition = ["profile = '{}'".format(transfersession.sync_session.profile)]
     partition_conditions = []
     # create condition for filtering by partitions
     for prefix in filter_prefixes:
@@ -435,69 +436,81 @@ def _queue_into_buffer(transfersession):
 
     fsics = list(fsics.items())
 
-    # chunk inserts all within one cursor
-    with connection.cursor() as cursor:
-        i = 0
-        chunk_size = 200
-        chunk = fsics[:chunk_size]
+    # chunk fsics creating multiple SQL selects which will be unioned before insert
+    i = 0
+    chunk_size = 200
+    chunk = fsics[:chunk_size]
+    select_buffers = []
+    select_rmc_buffers = []
 
-        while chunk:
-            last_saved_by_conditions = []
-            # create condition for all push FSICs where instance_ids are equal, but internal counters are higher than
-            # FSICs counters
-            for instance, counter in chunk:
-                last_saved_by_conditions += [
-                    "(last_saved_instance = '{0}' AND last_saved_counter > {1})".format(
-                        instance, counter
-                    )
-                ]
-            if fsics:
-                last_saved_by_conditions = [
-                    _join_with_logical_operator(last_saved_by_conditions, "OR")
-                ]
-
-            # combine conditions
-            fsic_and_partition_conditions = _join_with_logical_operator(
-                last_saved_by_conditions + partition_conditions, "AND"
+    while chunk:
+        # create condition for all push FSICs where instance_ids are equal, but internal counters are higher than
+        # FSICs counters
+        last_saved_by_conditions = [
+            "(last_saved_instance = '{0}' AND last_saved_counter > {1})".format(
+                instance, counter
             )
+            for instance, counter in chunk
+        ]
+        if last_saved_by_conditions:
+            last_saved_by_conditions = [
+                _join_with_logical_operator(last_saved_by_conditions, "OR")
+            ]
 
-            # filter by profile
-            where_condition = _join_with_logical_operator(
-                [
-                    fsic_and_partition_conditions,
-                    "profile = '{}'".format(transfersession.sync_session.profile),
-                ],
-                "AND",
-            )
+        # combine conditions and filter by profile
+        where_condition = _join_with_logical_operator(
+            profile_condition + last_saved_by_conditions + partition_conditions,
+            "AND",
+        )
 
-            # execute raw sql to take all records that match condition, to be put into buffer for transfer
-            queue_buffer = """INSERT INTO {outgoing_buffer}
-                            (model_uuid, serialized, deleted, last_saved_instance, last_saved_counter, hard_deleted,
-                             model_name, profile, partition, source_id, conflicting_serialized_data, transfer_session_id, _self_ref_fk)
-                            SELECT id, serialized, deleted, last_saved_instance, last_saved_counter, hard_deleted, model_name, profile, partition, source_id, conflicting_serialized_data, '{transfer_session_id}', _self_ref_fk
-                            FROM {store} WHERE {condition}""".format(
-                outgoing_buffer=Buffer._meta.db_table,
+        # execute raw sql to take all records that match condition, to be put into buffer for transfer
+        select_buffers.append(
+            """SELECT
+                   id, serialized, deleted, last_saved_instance, last_saved_counter, hard_deleted, model_name, profile,
+                   partition, source_id, conflicting_serialized_data, '{transfer_session_id}', _self_ref_fk
+               FROM {store} WHERE {condition}
+            """.format(
                 transfer_session_id=transfersession.id,
                 condition=where_condition,
                 store=Store._meta.db_table,
             )
-            cursor.execute(queue_buffer)
-            # take all record max counters that are foreign keyed onto store models, which were queued into the buffer
-            queue_rmc_buffer = """INSERT INTO {outgoing_rmcb}
-                                (instance_id, counter, transfer_session_id, model_uuid)
-                                SELECT instance_id, counter, '{transfer_session_id}', store_model_id
-                                FROM {record_max_counter} AS rmc
-                                INNER JOIN {outgoing_buffer} AS buffer ON rmc.store_model_id = buffer.model_uuid
-                                WHERE buffer.transfer_session_id = '{transfer_session_id}'
-                                """.format(
-                outgoing_rmcb=RecordMaxCounterBuffer._meta.db_table,
+        )
+        # take all record max counters that are foreign keyed onto store models, which were queued into the buffer
+        select_rmc_buffers.append(
+            """SELECT instance_id, counter, '{transfer_session_id}', store_model_id
+               FROM {record_max_counter} AS rmc
+               INNER JOIN {outgoing_buffer} AS buffer ON rmc.store_model_id = buffer.model_uuid
+               WHERE buffer.transfer_session_id = '{transfer_session_id}'
+            """.format(
                 transfer_session_id=transfersession.id,
                 record_max_counter=RecordMaxCounter._meta.db_table,
                 outgoing_buffer=Buffer._meta.db_table,
             )
-            cursor.execute(queue_rmc_buffer)
-            i += chunk_size
-            chunk = fsics[i : i + chunk_size]
+        )
+        i += chunk_size
+        chunk = fsics[i : i + chunk_size]
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """INSERT INTO {outgoing_buffer}
+               (model_uuid, serialized, deleted, last_saved_instance, last_saved_counter,
+               hard_deleted, model_name, profile, partition, source_id, conflicting_serialized_data,
+               transfer_session_id, _self_ref_fk)
+               {select}
+            """.format(
+                outgoing_buffer=Buffer._meta.db_table,
+                select=" UNION ".join(select_buffers),
+            )
+        )
+        cursor.execute(
+            """INSERT INTO {outgoing_rmcb}
+               (instance_id, counter, transfer_session_id, model_uuid)
+               {select}
+            """.format(
+                outgoing_rmcb=RecordMaxCounterBuffer._meta.db_table,
+                select=" UNION ".join(select_rmc_buffers),
+            )
+        )
 
 
 @transaction.atomic(using=USING_DB)

--- a/morango/sync/operations.py
+++ b/morango/sync/operations.py
@@ -442,9 +442,6 @@ def _queue_into_buffer(transfersession):
     chunk = fsics[:chunk_size]
     select_buffers = []
     select_rmc_buffers = []
-    transfersession_pk_field = next(
-        f for f in TransferSession._meta.fields if f.primary_key
-    )
 
     while chunk:
         # create condition for all push FSICs where instance_ids are equal, but internal counters are higher than
@@ -475,7 +472,7 @@ def _queue_into_buffer(transfersession):
                FROM {store} WHERE {condition}
             """.format(
                 transfer_session_id=transfersession.id,
-                transfer_session_id_type=transfersession_pk_field.rel_db_type(
+                transfer_session_id_type=TransferSession._meta.pk.rel_db_type(
                     connection
                 ),
                 condition=where_condition,
@@ -490,7 +487,7 @@ def _queue_into_buffer(transfersession):
                WHERE buffer.transfer_session_id = '{transfer_session_id}'
             """.format(
                 transfer_session_id=transfersession.id,
-                transfer_session_id_type=transfersession_pk_field.rel_db_type(
+                transfer_session_id_type=TransferSession._meta.pk.rel_db_type(
                     connection
                 ),
                 record_max_counter=RecordMaxCounter._meta.db_table,

--- a/tests/testapp/tests/sync/test_operations.py
+++ b/tests/testapp/tests/sync/test_operations.py
@@ -86,6 +86,22 @@ class QueueStoreIntoBufferTestCase(TestCase):
         self.assertRecordsBuffered(self.data["group1_c2"])
         self.assertRecordsBuffered(self.data["group2_c1"])
 
+    def test_very_many_fsics(self):
+        """
+        Regression test against 'Expression tree is too large (maximum depth 1000)' error with many fsics
+        """
+        fsics = {self.data["group1_id"].id: 1, self.data["group2_id"].id: 1}
+        fsics.update({
+            uuid.uuid4().hex: i
+            for i in range(2000)
+        })
+        self.transfer_session.client_fsic = json.dumps(fsics)
+        _queue_into_buffer(self.transfer_session)
+        # ensure all store and buffer records are buffered
+        self.assertRecordsBuffered(self.data["group1_c1"])
+        self.assertRecordsBuffered(self.data["group1_c2"])
+        self.assertRecordsBuffered(self.data["group2_c1"])
+
     def test_fsic_specific_id(self):
         fsics = {self.data["group2_id"].id: 1}
         self.transfer_session.client_fsic = json.dumps(fsics)


### PR DESCRIPTION
## Summary
- Fixes `Expression tree is too large (maximum depth 1000)` issue originating from client or server having many instance counters

## TODO
- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance
- New test fails without change

## Issues addressed

Resolves https://github.com/learningequality/morango/issues/114

