### PR TITLE
Add new ids argument to cleanupsyncs command

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mkdir -p dist
+make dist
+buildkite-agent artifact upload 'dist/*.whl'
+buildkite-agent artifact upload 'dist/*.tar.gz'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,4 +7,4 @@ steps:
 
   - label: Build python package
     command:
-     - make dist
+     - .buildkite/build.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,10 @@
+steps:
+  - label: Install build packages
+    command:
+     - pip install setuptools wheel
+
+  - wait
+
+  - label: Build python package
+    command:
+     - make dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ List of the most important changes for each release.
 ## 0.6.5
 - Sets queuing limit of 100k combined FSICs between client and server
 - Fixes SQL expression tree error when there are many FSICs, up to 100k limit
+- Adds additional `ids` argument to `cleanupsyncs` management command
 
 ## 0.6.4
 - Fixes issue with `assert` statement removal during python optimization

--- a/morango/management/commands/cleanupsyncs.py
+++ b/morango/management/commands/cleanupsyncs.py
@@ -13,7 +13,8 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             "--ids",
-            type=str,
+            type=lambda ids: ids.split(","),
+            default=None,
             help="Comma separated list of SyncSession IDs to filter against"
         )
         parser.add_argument(
@@ -36,7 +37,7 @@ class Command(BaseCommand):
 
         # if ids arg was passed, filter down sessions to only those IDs if included by expiration filter
         if options["ids"]:
-            oldsessions = oldsessions.filter(sync_session_id__in=options["ids"].split(","))
+            oldsessions = oldsessions.filter(sync_session_id__in=options["ids"])
 
         sesscount = oldsessions.count()
 

--- a/morango/management/commands/cleanupsyncs.py
+++ b/morango/management/commands/cleanupsyncs.py
@@ -12,6 +12,11 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
+            "--ids",
+            type=str,
+            help="Comma separated list of SyncSession IDs to filter against"
+        )
+        parser.add_argument(
             "--expiration",
             action="store",
             type=int,
@@ -28,6 +33,11 @@ class Command(BaseCommand):
         oldsessions = TransferSession.objects.filter(
             last_activity_timestamp__lt=cutoff, active=True
         )
+
+        # if ids arg was passed, filter down sessions to only those IDs if included by expiration filter
+        if options["ids"]:
+            oldsessions = oldsessions.filter(sync_session_id__in=options["ids"].split(","))
+
         sesscount = oldsessions.count()
 
         # loop over the stale sessions one by one to close them out

--- a/tests/testapp/tests/test_management_commands.py
+++ b/tests/testapp/tests/test_management_commands.py
@@ -72,3 +72,8 @@ class CleanupSyncsTestCase(TestCase):
         call_command("cleanupsyncs", expiration=1)
         assert_session_is_cleared(self.transfersession_old)
         assert_session_is_cleared(self.transfersession_new)
+
+    def test_filtering_sessions_cleared(self):
+        call_command("cleanupsyncs", ids=self.syncsession_old.id, expiration=0)
+        assert_session_is_cleared(self.transfersession_old)
+        assert_session_is_not_cleared(self.transfersession_new)

--- a/tests/testapp/tests/test_management_commands.py
+++ b/tests/testapp/tests/test_management_commands.py
@@ -6,8 +6,6 @@ from django.test import TestCase
 from django.utils import timezone
 
 from .helpers import create_buffer_and_store_dummy_data
-from morango.models.core import Buffer
-from morango.models.core import RecordMaxCounterBuffer
 from morango.models.core import SyncSession
 from morango.models.core import TransferSession
 
@@ -74,6 +72,12 @@ class CleanupSyncsTestCase(TestCase):
         assert_session_is_cleared(self.transfersession_new)
 
     def test_filtering_sessions_cleared(self):
-        call_command("cleanupsyncs", ids=self.syncsession_old.id, expiration=0)
+        call_command("cleanupsyncs", ids=[self.syncsession_old.id], expiration=0)
         assert_session_is_cleared(self.transfersession_old)
         assert_session_is_not_cleared(self.transfersession_new)
+
+    def test_multiple_ids_as_list(self):
+        ids = [self.syncsession_old.id, self.syncsession_new.id]
+        call_command("cleanupsyncs", ids=ids, expiration=0)
+        assert_session_is_cleared(self.transfersession_old)
+        assert_session_is_cleared(self.transfersession_new)


### PR DESCRIPTION
## Summary
- Adds `ids` argument to cleanup management command so we can initiate targeted cleanup of incomplete SoUD syncs
- Migrates buildkite to pipeline.yml (resolves: https://buildkite.com/learningequality/morango/builds/154#d38eb321-f1f9-4d70-b93a-34efb48d0fb3)

## TODO

- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance
- Run management command with `--ids` arg
