### PR TITLE
Fix legacy update server's records total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ List of the most important changes for each release.
 
 ## 0.6.6
 - Adds an asymmetry to FSIC calculation to ensure all matching data is synced.
+- Fixes issue syncing with Morangos pre-0.6.0 causing pushed records to not be dequeued
 
 ## 0.6.5
 - Sets queuing limit of 100k combined FSICs between client and server

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.6a0"
+__version__ = "0.6.6a1"

--- a/morango/constants/settings.py
+++ b/morango/constants/settings.py
@@ -27,7 +27,7 @@ MORANGO_TRANSFERRING_OPERATIONS = (
 MORANGO_DEQUEUE_OPERATIONS = (
     "morango.sync.operations:ProducerDequeueOperation",
     "morango.sync.operations:ReceiverDequeueOperation",
-    "morango.sync.operations:LegacyDequeueOperation",
+    "morango.sync.operations:LegacyNetworkDequeueOperation",
     "morango.sync.operations:NetworkDequeueOperation",
 )
 MORANGO_DESERIALIZE_OPERATIONS = (

--- a/morango/sync/operations.py
+++ b/morango/sync/operations.py
@@ -1127,7 +1127,18 @@ class LegacyNetworkQueueOperation(NetworkLegacyNoOpMixin, NetworkOperation):
     Without ASYNC_OPERATIONS capability, the server will perform queuing during initialization
     """
 
-    pass
+    def handle(self, context):
+        """
+        :type context: NetworkSessionContext
+        """
+        self._assert(ASYNC_OPERATIONS not in context.capabilities)
+
+        # When pushing, this should occur after queuing locally, so we need to update the server
+        # with how many records we've queued for the push
+        if context.is_push:
+            self.update_transfer_session(context, records_total=context.transfer_session.records_total)
+
+        return transfer_statuses.COMPLETED
 
 
 class NetworkQueueOperation(NetworkOperation):
@@ -1237,7 +1248,7 @@ class NetworkPullTransferOperation(NetworkOperation):
         return op_status
 
 
-class LegacyDequeueOperation(NetworkLegacyNoOpMixin, NetworkOperation):
+class LegacyNetworkDequeueOperation(NetworkLegacyNoOpMixin, NetworkOperation):
     """
     Without ASYNC_OPERATIONS capability, the server will perform dequeuing during cleanup
     """

--- a/morango/sync/operations.py
+++ b/morango/sync/operations.py
@@ -1046,6 +1046,10 @@ class LegacyNetworkInitializeOperation(NetworkOperation):
         data = self.create_transfer_session(context)
         context.transfer_session.server_fsic = data.get("server_fsic") or "{}"
 
+        # A legacy instance performs queuing during the creation of the transfer session, so since we use a new
+        # workflow we need to update the network server when pushing to say how many records we've queued. For pull,
+        # we handle that here in the initialization/creation of the transfer session,
+        # since that's when it's first available.
         if context.transfer_session.pull:
             context.transfer_session.records_total = data.get("records_total", 0)
 
@@ -1133,8 +1137,9 @@ class LegacyNetworkQueueOperation(NetworkLegacyNoOpMixin, NetworkOperation):
         """
         self._assert(ASYNC_OPERATIONS not in context.capabilities)
 
-        # When pushing, this should occur after queuing locally, so we need to update the server
-        # with how many records we've queued for the push
+        # A legacy instance performs queuing during the creation of the transfer session, so since we use a new
+        # workflow we need to update the network server when pushing to say how many records we've queued. For pull,
+        # we handle that in the initialization/creation of the transfer session, since that's when it's first available.
         if context.is_push:
             self.update_transfer_session(context, records_total=context.transfer_session.records_total)
 


### PR DESCRIPTION
## Summary
- Ensures we update `records_total` on the server side after queuing for push
- Without `records_total`, [legacy servers won't dequeue](https://github.com/learningequality/morango/blob/v0.5.6/morango/api/viewsets.py#L393) even though we pushed data

## TODO

- [ ] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

List the issues solved or partly solved by the PR

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)
