### PR TITLE
Support for custom instance info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ List of the most important changes for each release.
 
 ## 0.6.6
 - Adds an asymmetry to FSIC calculation to ensure all matching data is synced.
+- Adds support for defining custom instance info returned from info API and during sync session creation
+- Updates `cleanupsyncs` management command to only close sync sessions if there are no other related transfer sessions active
 - Fixes issue syncing with Morangos pre-0.6.0 causing pushed records to not be dequeued
 
 ## 0.6.5

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.6a1"
+__version__ = "0.6.6"

--- a/morango/api/viewsets.py
+++ b/morango/api/viewsets.py
@@ -507,13 +507,15 @@ class BufferViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 class MorangoInfoViewSet(viewsets.ViewSet):
     def retrieve(self, request, pk=None):
         (id_model, _) = InstanceIDModel.get_or_create_current_instance()
-        m_info = {
+        # include custom instance info as well
+        m_info = id_model.instance_info.copy()
+        m_info.update({
             "instance_hash": id_model.get_proquint(),
             "instance_id": id_model.id,
             "system_os": platform.system(),
             "version": morango.__version__,
             "capabilities": CAPABILITIES,
-        }
+        })
         return response.Response(m_info)
 
 

--- a/morango/constants/settings.py
+++ b/morango/constants/settings.py
@@ -2,6 +2,7 @@ ALLOW_CERTIFICATE_PUSHING = False
 MORANGO_SERIALIZE_BEFORE_QUEUING = True
 MORANGO_DESERIALIZE_AFTER_DEQUEUING = True
 MORANGO_DISALLOW_ASYNC_OPERATIONS = False
+MORANGO_INSTANCE_INFO = {}
 MORANGO_INITIALIZE_OPERATIONS = (
     "morango.sync.operations:InitializeOperation",
     "morango.sync.operations:LegacyNetworkInitializeOperation",

--- a/morango/management/commands/cleanupsyncs.py
+++ b/morango/management/commands/cleanupsyncs.py
@@ -82,4 +82,3 @@ class Command(BaseCommand):
                 )
                 sync_session.active = False
                 sync_session.save()
-

--- a/morango/models/core.py
+++ b/morango/models/core.py
@@ -20,6 +20,7 @@ from django.db.models.fields.related import ForeignKey
 from django.db.models.functions import Cast
 from django.utils import six
 from django.utils import timezone
+from django.utils.functional import cached_property
 
 from functools import reduce
 
@@ -38,6 +39,7 @@ from morango.models.utils import get_0_5_mac_address
 from morango.constants import transfer_stages
 from morango.constants import transfer_statuses
 from morango.utils import _assert
+from morango.utils import SETTINGS
 
 logger = logging.getLogger(__name__)
 
@@ -120,6 +122,14 @@ class InstanceIDModel(models.Model):
     current = models.BooleanField(default=True)
     db_path = models.CharField(max_length=1000)
     system_id = models.CharField(max_length=100, blank=True)
+
+    @property
+    def instance_info(self):
+        """
+        Getter to access custom instance info defined in settings
+        :return: dict
+        """
+        return SETTINGS.MORANGO_INSTANCE_INFO
 
     @classmethod
     @transaction.atomic
@@ -234,6 +244,14 @@ class SyncSession(models.Model):
 
     # system process ID for ensuring same sync session does not run in parallel
     process_id = models.IntegerField(blank=True, null=True)
+
+    @cached_property
+    def client_instance_data(self):
+        return json.loads(self.client_instance)
+
+    @cached_property
+    def server_instance_data(self):
+        return json.loads(self.server_instance)
 
 
 class TransferSession(models.Model):

--- a/morango/registry.py
+++ b/morango/registry.py
@@ -14,6 +14,7 @@ from morango.constants import transfer_stages
 from morango.errors import InvalidMorangoModelConfiguration
 from morango.errors import ModelRegistryNotReady
 from morango.errors import UnsupportedFieldType
+from morango.utils import do_import
 from morango.utils import SETTINGS
 
 
@@ -211,8 +212,7 @@ class SessionMiddlewareOperations(list):
         :type callable_imports: str[]
         """
         for callable_import in callable_imports:
-            callable_module, callable_name = callable_import.rsplit(":", 1)
-            middleware_callable = getattr(import_module(callable_module), callable_name)
+            middleware_callable = do_import(callable_import)
             if inspect.isclass(middleware_callable):
                 self.append(middleware_callable())
             else:

--- a/morango/registry.py
+++ b/morango/registry.py
@@ -5,7 +5,6 @@ This class is registered at app load time for morango in `apps.py`.
 import sys
 import inspect
 from collections import OrderedDict
-from importlib import import_module
 
 from django.db.models.fields.related import ForeignKey
 from django.utils import six

--- a/tests/testapp/facility_profile/custom.py
+++ b/tests/testapp/facility_profile/custom.py
@@ -1,0 +1,4 @@
+CUSTOM_INSTANCE_INFO = {
+    "this_is_a_test": "import",
+    "version": 1.0,
+}

--- a/tests/testapp/tests/sync/test_syncsession.py
+++ b/tests/testapp/tests/sync/test_syncsession.py
@@ -108,11 +108,15 @@ class NetworkSyncConnectionTestCase(LiveServerTestCase):
         )
         self.key = SharedKey.get_or_create_shared_key()
 
+    @override_settings(MORANGO_INSTANCE_INFO={"this_is_a_test": "yes"})
     @mock.patch.object(SyncSession.objects, "create", return_value=None)
     def test_creating_sync_session_successful(self, mock_object):
         self.assertEqual(SyncSession.objects.filter(active=True).count(), 0)
         self.network_connection.create_sync_session(self.subset_cert, self.root_cert)
         self.assertEqual(SyncSession.objects.filter(active=True).count(), 1)
+        sync_session = SyncSession.objects.get(active=True)
+        self.assertIn("this_is_a_test", sync_session.client_instance_data)
+        self.assertEqual("yes", sync_session.client_instance_data["this_is_a_test"])
 
     @mock.patch.object(NetworkSyncConnection, "_create_sync_session")
     @mock.patch.object(Certificate, "verify", return_value=False)

--- a/tests/testapp/tests/test_api.py
+++ b/tests/testapp/tests/test_api.py
@@ -569,6 +569,7 @@ class SyncSessionEndpointTestCase(CertificateTestCaseMixin, APITestCase):
         # check that the syncsession was not created
         self.assertEqual(SyncSession.objects.count(), 0)
 
+    @override_settings(MORANGO_INSTANCE_INFO={"this_is_a_test": "yes"})
     def test_syncsession_can_be_created(self):
 
         data = self.get_initial_syncsession_data_for_request()
@@ -581,6 +582,9 @@ class SyncSessionEndpointTestCase(CertificateTestCaseMixin, APITestCase):
         # make the API call to create the SyncSession
         response = self.client.post(reverse("syncsessions-list"), data, format="json")
         self.assertEqual(response.status_code, 201)
+        server_instance_data = json.loads(response.data["server_instance"])
+        self.assertIn("this_is_a_test", server_instance_data)
+        self.assertEqual("yes", server_instance_data["this_is_a_test"])
 
         # check that the cert chain was deserialized
         self.assertEqual(Certificate.objects.count(), self.original_cert_count)
@@ -1140,6 +1144,14 @@ class MorangoInfoTestCase(APITestCase):
                 reverse("morangoinfo-detail", kwargs={"pk": 1}), format="json"
             )
         self.assertNotEqual(m_info.data["instance_hash"], old_id_hash)
+
+    @override_settings(MORANGO_INSTANCE_INFO={"this_is_a_test": "yes"})
+    def test_custom_instance_info(self):
+        self.m_info = self.client.get(
+            reverse("morangoinfo-detail", kwargs={"pk": 1}), format="json"
+        )
+        self.assertIn("this_is_a_test", self.m_info.data)
+        self.assertEqual(self.m_info.data["this_is_a_test"], "yes")
 
 
 class PublicKeyTestCase(APITestCase):

--- a/tests/testapp/tests/test_api.py
+++ b/tests/testapp/tests/test_api.py
@@ -1,13 +1,12 @@
-import base64
 import json
 import sys
 import uuid
 
-import mock
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
 from django.urls.exceptions import NoReverseMatch
 from django.utils import timezone
+from django.utils.functional import SimpleLazyObject
 from facility_profile.models import MyUser
 from rest_framework.test import APITestCase as BaseTestCase
 from test.support import EnvironmentVarGuard
@@ -1128,6 +1127,13 @@ class BufferEndpointTestCase(CertificateTestCaseMixin, APITestCase):
         )
 
 
+def _lazy_settings():
+    return {"this_is_a_test": "lazy"}
+
+
+lazy_settings = SimpleLazyObject(_lazy_settings)
+
+
 class MorangoInfoTestCase(APITestCase):
     def setUp(self):
         InstanceIDModel.get_or_create_current_instance()
@@ -1152,6 +1158,22 @@ class MorangoInfoTestCase(APITestCase):
         )
         self.assertIn("this_is_a_test", self.m_info.data)
         self.assertEqual(self.m_info.data["this_is_a_test"], "yes")
+
+    @override_settings(MORANGO_INSTANCE_INFO="facility_profile.custom:CUSTOM_INSTANCE_INFO")
+    def test_custom_instance_info__import_path(self):
+        self.m_info = self.client.get(
+            reverse("morangoinfo-detail", kwargs={"pk": 1}), format="json"
+        )
+        self.assertIn("this_is_a_test", self.m_info.data)
+        self.assertEqual(self.m_info.data["this_is_a_test"], "import")
+
+    @override_settings(MORANGO_INSTANCE_INFO=lazy_settings)
+    def test_custom_instance_info__lazy(self):
+        self.m_info = self.client.get(
+            reverse("morangoinfo-detail", kwargs={"pk": 1}), format="json"
+        )
+        self.assertIn("this_is_a_test", self.m_info.data)
+        self.assertEqual(self.m_info.data["this_is_a_test"], "lazy")
 
 
 class PublicKeyTestCase(APITestCase):


### PR DESCRIPTION
## Summary
- Adds new dict setting `MORANGO_INSTANCE_INFO`
- Updates serializer for `InstanceIDModel` to include custom instance info from new setting
- Updates info API endpoint to include custom instance info from new setting

## TODO

- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance

## Issues addressed
Resolves https://github.com/learningequality/morango/issues/136