### PR TITLE
Support closing sync sessions if all related transfer sessions have been closed

### DIFF
--- a/tests/testapp/tests/test_management_commands.py
+++ b/tests/testapp/tests/test_management_commands.py
@@ -10,17 +10,19 @@ from morango.models.core import SyncSession
 from morango.models.core import TransferSession
 
 
-def _create_sessions(last_activity_offset=0):
+def _create_sessions(last_activity_offset=0, sync_session=None):
 
     last_activity_timestamp = timezone.now() - datetime.timedelta(
         hours=last_activity_offset
     )
 
-    sync_session = SyncSession.objects.create(
-        id=uuid.uuid4().hex,
-        profile="facilitydata",
-        last_activity_timestamp=last_activity_timestamp,
-    )
+    if sync_session is None:
+        sync_session = SyncSession.objects.create(
+            id=uuid.uuid4().hex,
+            profile="facilitydata",
+            last_activity_timestamp=last_activity_timestamp,
+        )
+
     transfer_session = TransferSession.objects.create(
         id=uuid.uuid4().hex,
         sync_session=sync_session,
@@ -31,24 +33,6 @@ def _create_sessions(last_activity_offset=0):
     return sync_session, transfer_session
 
 
-def assert_session_is_cleared(transfersession):
-    transfersession.refresh_from_db()
-    transfersession.sync_session.refresh_from_db()
-    assert transfersession.buffer_set.all().count() == 0
-    assert transfersession.recordmaxcounterbuffer_set.all().count() == 0
-    assert transfersession.active == False
-    assert transfersession.sync_session.active == False
-
-
-def assert_session_is_not_cleared(transfersession):
-    transfersession.refresh_from_db()
-    transfersession.sync_session.refresh_from_db()
-    assert transfersession.buffer_set.all().count() > 0
-    assert transfersession.recordmaxcounterbuffer_set.all().count() > 0
-    assert transfersession.active == True
-    assert transfersession.sync_session.active == True
-
-
 class CleanupSyncsTestCase(TestCase):
     def setUp(self):
         self.syncsession_old, self.transfersession_old = _create_sessions(24)
@@ -56,28 +40,70 @@ class CleanupSyncsTestCase(TestCase):
         self.data_old = create_buffer_and_store_dummy_data(self.transfersession_old.id)
         self.data_new = create_buffer_and_store_dummy_data(self.transfersession_new.id)
 
+    def assertTransferSessionState(self, transfer_session, cleared):
+        transfer_session.refresh_from_db()
+        self.assertNotEqual(cleared, transfer_session.buffer_set.all().exists())
+        self.assertNotEqual(cleared, transfer_session.recordmaxcounterbuffer_set.all().exists())
+        self.assertNotEqual(cleared, transfer_session.active)
+
+    def assertTransferSessionIsCleared(self, transfer_session):
+        self.assertTransferSessionState(transfer_session, True)
+
+    def assertTransferSessionIsNotCleared(self, transfer_session):
+        self.assertTransferSessionState(transfer_session, False)
+
+    def assertSyncSessionState(self, sync_session, active):
+        sync_session.refresh_from_db()
+        self.assertEqual(active, sync_session.active)
+
+    def assertSyncSessionIsActive(self, sync_session):
+        self.assertSyncSessionState(sync_session, True)
+
+    def assertSyncSessionIsNotActive(self, sync_session):
+        self.assertSyncSessionState(sync_session, False)
+
     def test_no_sessions_cleared(self):
         call_command("cleanupsyncs", expiration=48)
-        assert_session_is_not_cleared(self.transfersession_old)
-        assert_session_is_not_cleared(self.transfersession_new)
+        self.assertTransferSessionIsNotCleared(self.transfersession_old)
+        self.assertSyncSessionIsActive(self.syncsession_old)
+        self.assertTransferSessionIsNotCleared(self.transfersession_new)
+        self.assertSyncSessionIsActive(self.syncsession_new)
 
     def test_some_sessions_cleared(self):
         call_command("cleanupsyncs", expiration=6)
-        assert_session_is_cleared(self.transfersession_old)
-        assert_session_is_not_cleared(self.transfersession_new)
+        self.assertTransferSessionIsCleared(self.transfersession_old)
+        self.assertSyncSessionIsNotActive(self.syncsession_old)
+        self.assertTransferSessionIsNotCleared(self.transfersession_new)
+        self.assertSyncSessionIsActive(self.syncsession_new)
+
+    def test_sync_session_handling(self):
+        _, old_sync_new_transfer = _create_sessions(2, sync_session=self.syncsession_old)
+        create_buffer_and_store_dummy_data(old_sync_new_transfer.id)
+        call_command("cleanupsyncs", expiration=6)
+        self.assertTransferSessionIsCleared(self.transfersession_old)
+        self.assertTransferSessionIsNotCleared(old_sync_new_transfer)
+        self.assertSyncSessionIsActive(self.syncsession_old)
+        self.assertTransferSessionIsNotCleared(self.transfersession_new)
+        self.assertSyncSessionIsActive(self.syncsession_new)
 
     def test_all_sessions_cleared(self):
         call_command("cleanupsyncs", expiration=1)
-        assert_session_is_cleared(self.transfersession_old)
-        assert_session_is_cleared(self.transfersession_new)
+        self.assertTransferSessionIsCleared(self.transfersession_old)
+        self.assertSyncSessionIsNotActive(self.syncsession_old)
+        self.assertTransferSessionIsCleared(self.transfersession_new)
+        self.assertSyncSessionIsNotActive(self.syncsession_new)
 
     def test_filtering_sessions_cleared(self):
         call_command("cleanupsyncs", ids=[self.syncsession_old.id], expiration=0)
-        assert_session_is_cleared(self.transfersession_old)
-        assert_session_is_not_cleared(self.transfersession_new)
+        self.assertTransferSessionIsCleared(self.transfersession_old)
+        self.assertSyncSessionIsNotActive(self.syncsession_old)
+        self.assertTransferSessionIsNotCleared(self.transfersession_new)
+        self.assertSyncSessionIsActive(self.syncsession_new)
 
     def test_multiple_ids_as_list(self):
         ids = [self.syncsession_old.id, self.syncsession_new.id]
         call_command("cleanupsyncs", ids=ids, expiration=0)
-        assert_session_is_cleared(self.transfersession_old)
-        assert_session_is_cleared(self.transfersession_new)
+        self.assertTransferSessionIsCleared(self.transfersession_old)
+        self.assertSyncSessionIsNotActive(self.syncsession_old)
+        self.assertTransferSessionIsCleared(self.transfersession_new)
+        self.assertSyncSessionIsNotActive(self.syncsession_new)


### PR DESCRIPTION
## Summary
- Update `cleanupsyncs` to not forcefully close the sync session in case there are other transfer sessions filtered out by last activity timestamp filter
- Tweak logic to also close sync sessions, even if there are no active transfer sessions to cleanup

## TODO

- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance
- Supports Kolibri behavior that keeps sync sessions open (active), and for cleaning up sync sessions which have been left open

