### PR TITLE
Revert "Only regenerate _morango_source_id if it is None"

### DIFF
--- a/morango/models/core.py
+++ b/morango/models/core.py
@@ -831,10 +831,9 @@ class SyncableModel(UUIDModelMixin):
         return sha2_uuid(partition_value, source_id_value, model_name)
 
     def calculate_uuid(self):
-        if self._morango_source_id is None: 
-            self._morango_source_id = self.calculate_source_id()
-            if self._morango_source_id is None:
-                self._morango_source_id = uuid.uuid4().hex
+        self._morango_source_id = self.calculate_source_id()
+        if self._morango_source_id is None:
+            self._morango_source_id = uuid.uuid4().hex
 
         namespaced_id = self.compute_namespaced_id(
             self.calculate_partition(), self._morango_source_id, self.morango_model_name


### PR DESCRIPTION
Reverts learningequality/morango#115

Nevermind! @rtibbles reminded me that the reason we haven't merged this is that the tests need to be updated to work with this first.