### PR TITLE
Also regenerate source ids when empty string and strictly enforce calculation

### DIFF
--- a/morango/api/urls.py
+++ b/morango/api/urls.py
@@ -10,16 +10,16 @@ from .viewsets import SyncSessionViewSet
 from .viewsets import TransferSessionViewSet
 
 router = routers.SimpleRouter()
-router.register(r"certificates", CertificateViewSet, base_name="certificates")
+router.register(r"certificates", CertificateViewSet, basename="certificates")
 router.register(
-    r"certificatechain", CertificateChainViewSet, base_name="certificatechain"
+    r"certificatechain", CertificateChainViewSet, basename="certificatechain"
 )
-router.register(r"nonces", NonceViewSet, base_name="nonces")
-router.register(r"syncsessions", SyncSessionViewSet, base_name="syncsessions")
+router.register(r"nonces", NonceViewSet, basename="nonces")
+router.register(r"syncsessions", SyncSessionViewSet, basename="syncsessions")
 router.register(
-    r"transfersessions", TransferSessionViewSet, base_name="transfersessions"
+    r"transfersessions", TransferSessionViewSet, basename="transfersessions"
 )
-router.register(r"buffers", BufferViewSet, base_name="buffers")
-router.register(r"morangoinfo", MorangoInfoViewSet, base_name="morangoinfo")
-router.register(r"publickey", PublicKeyViewSet, base_name="publickey")
+router.register(r"buffers", BufferViewSet, basename="buffers")
+router.register(r"morangoinfo", MorangoInfoViewSet, basename="morangoinfo")
+router.register(r"publickey", PublicKeyViewSet, basename="publickey")
 urlpatterns = router.urls

--- a/morango/errors.py
+++ b/morango/errors.py
@@ -64,3 +64,7 @@ class MorangoContextUpdateError(MorangoError):
 
 class MorangoLimitExceeded(MorangoError):
     pass
+
+
+class InvalidMorangoSourceId(MorangoError):
+    pass

--- a/morango/models/core.py
+++ b/morango/models/core.py
@@ -473,7 +473,7 @@ class Store(AbstractStore):
 
             except (exceptions.ValidationError, exceptions.ObjectDoesNotExist) as e:
 
-                logger.warn(
+                logger.warning(
                     "Error deserializing instance of {model} with id {id}: {error}".format(
                         model=klass_model.__name__, id=app_model.id, error=e
                     )

--- a/morango/models/core.py
+++ b/morango/models/core.py
@@ -831,9 +831,10 @@ class SyncableModel(UUIDModelMixin):
         return sha2_uuid(partition_value, source_id_value, model_name)
 
     def calculate_uuid(self):
-        self._morango_source_id = self.calculate_source_id()
-        if self._morango_source_id is None:
-            self._morango_source_id = uuid.uuid4().hex
+        if not self._morango_source_id:
+            self._morango_source_id = self.calculate_source_id()
+            if not self._morango_source_id:
+                self._morango_source_id = uuid.uuid4().hex
 
         namespaced_id = self.compute_namespaced_id(
             self.calculate_partition(), self._morango_source_id, self.morango_model_name

--- a/morango/models/core.py
+++ b/morango/models/core.py
@@ -25,6 +25,7 @@ from django.utils.functional import cached_property
 from functools import reduce
 
 from morango import proquint
+from morango.errors import InvalidMorangoSourceId
 from morango.registry import syncable_models
 from morango.models.certificates import Certificate
 from morango.models.certificates import Filter
@@ -642,7 +643,9 @@ class DatabaseMaxCounter(AbstractCounter):
             )
             qs = qs.filter(filter_matches=True)
             filt_maxes = qs.values("instance_id").annotate(maxval=Max("counter"))
-            per_filter_max.append({dmc["instance_id"]: dmc["maxval"] for dmc in filt_maxes})
+            per_filter_max.append(
+                {dmc["instance_id"]: dmc["maxval"] for dmc in filt_maxes}
+            )
 
         instance_id_lists = [maxes.keys() for maxes in per_filter_max]
         all_instance_ids = reduce(set.union, instance_id_lists, set())
@@ -833,8 +836,16 @@ class SyncableModel(UUIDModelMixin):
     def calculate_uuid(self):
         if not self._morango_source_id:
             self._morango_source_id = self.calculate_source_id()
-            if not self._morango_source_id:
+            if self._morango_source_id is None:
                 self._morango_source_id = uuid.uuid4().hex
+            elif self._morango_source_id == "":
+                # undefined behavior, which due to dynamic nature of calculating it, this could be an unintentional bug
+                # so we raise an error to strictly enforce this
+                raise InvalidMorangoSourceId(
+                    "{}.calculate_source_id() returned empty string".format(
+                        self.__class__.__name__
+                    )
+                )
 
         namespaced_id = self.compute_namespaced_id(
             self.calculate_partition(), self._morango_source_id, self.morango_model_name

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,7 +3,7 @@ factory-boy==2.7.0
 fake-factory==0.5.7
 coverage==4.5.1
 mock==2.0.0
-pytest==3.7.1
-pytest-cov==2.5.1
-pytest-django==3.3.3
-typing
+pytest==3.10.1
+pytest-cov==2.8.1
+pytest-django==3.10.0
+more-itertools<=8.10.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,6 +5,6 @@ coverage==4.5.1
 mock==2.0.0
 pytest==3.10.1
 pytest-cov==2.8.1
-pytest-django==3.10.0
+pytest-django==3.8.0
 more-itertools<=8.10.0
 typing

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,3 +7,4 @@ pytest==3.10.1
 pytest-cov==2.8.1
 pytest-django==3.10.0
 more-itertools<=8.10.0
+typing

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
                  'morango'},
     include_package_data=True,
     install_requires=[
-        "django<1.12",
+        "django>=1.10,<2",
         "django-mptt<0.10.0",
         "rsa>=3.4.2,<3.5",
         "djangorestframework==3.9.1",

--- a/tests/testapp/facility_profile/models.py
+++ b/tests/testapp/facility_profile/models.py
@@ -110,7 +110,7 @@ class ProxyParent(MorangoMPTTModel):
             self.kind = self._KIND
 
     def calculate_source_id(self, *args, **kwargs):
-        return ''
+        return None
 
     def calculate_partition(self, *args, **kwargs):
         return ''
@@ -131,7 +131,7 @@ class ProxyModel(ProxyParent):
         proxy = True
 
     def calculate_source_id(self, *args, **kwargs):
-        return ''
+        return None
 
     def calculate_partition(self, *args, **kwargs):
         return ''

--- a/tests/testapp/testapp/settings.py
+++ b/tests/testapp/testapp/settings.py
@@ -42,7 +42,7 @@ INSTALLED_APPS = [
     'facility_profile',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/tests/testapp/tests/test_api.py
+++ b/tests/testapp/tests/test_api.py
@@ -2,7 +2,7 @@ import json
 import sys
 import uuid
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from django.urls.exceptions import NoReverseMatch
 from django.utils import timezone


### PR DESCRIPTION
## Summary
- Allows empty string to trigger source id regeneration
- Raises an error if `calculate_source_id` returns an empty string which is undefined behavior
- Fixes test issues and deprecation warnings

## TODO

- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Issues addressed

Resolves https://github.com/learningequality/morango/issues/141

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)
