### PR TITLE
Add chunking to FSIC v2 queuing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 List of the most important changes for each release.
 
+## 0.6.8
+- Fixes subset syncing issues by introducing new FSIC v2 format
+
 ## 0.6.7
 - Updates transfer status fields to be nullable and corrects prior migration
 

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.8a0"
+__version__ = "0.6.8a1"

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.8a1"
+__version__ = "0.6.8"

--- a/morango/models/fsic_utils.py
+++ b/morango/models/fsic_utils.py
@@ -58,7 +58,7 @@ def remove_redundant_instance_counters(raw_fsic):
                         del sub_dict[inst]
 
 
-def expand_fsic_for_use(raw_fsic):
+def expand_fsic_for_use(raw_fsic, sync_filter):
     """
     Convert the raw FSIC format from the wire into a format usable for filtering, by propagating super partition counts
     down into sub-partitions. Returns only the expanded subpartition dict, discarding the super partitions.
@@ -66,7 +66,16 @@ def expand_fsic_for_use(raw_fsic):
     assert "super" in raw_fsic
     assert "sub" in raw_fsic
     raw_fsic = raw_fsic.copy()
+    
+    # ensure that the subpartition list includes all the filter partitions
+    for partition in sync_filter:
+        if partition not in raw_fsic["sub"]:
+            raw_fsic["sub"][partition] = {}
+    
+    # get a list of any subpartitions that are subordinate to other subpartitions
     subordinates = _get_sub_partitions(raw_fsic["sub"].keys())
+    
+    # propagate the super partition counts down into sub-partitions
     for sub_part, sub_fsic in raw_fsic["sub"].items():
         # skip any partitions that are subordinate to another sub-partition
         if sub_part in subordinates:
@@ -78,6 +87,12 @@ def expand_fsic_for_use(raw_fsic):
                 for instance, counter in super_fsic.items():
                     if counter > sub_fsic.get(instance, 0):
                         sub_fsic[instance] = counter
+    
+    # remove any empty subpartitions
+    for sub_part in list(raw_fsic["sub"].keys()):
+        if not raw_fsic["sub"][sub_part]:
+            del raw_fsic["sub"][sub_part]
+    
     return raw_fsic["sub"]
 
 

--- a/morango/models/fsic_utils.py
+++ b/morango/models/fsic_utils.py
@@ -85,7 +85,7 @@ def expand_fsic_for_use(raw_fsic, sync_filter):
     assert "sub" in raw_fsic
     raw_fsic = raw_fsic.copy()
 
-    # ensure that the subpartition list includes all the filter partitions    
+    # ensure that the subpartition list includes all the filter partitions
     _add_filter_partitions(raw_fsic["sub"], sync_filter)
 
     # get a list of any subpartitions that are subordinate to other subpartitions

--- a/morango/models/fsic_utils.py
+++ b/morango/models/fsic_utils.py
@@ -171,9 +171,10 @@ def chunk_fsic_v2(fsics, chunk_size):
     chunked_fsics = []
     current_chunk = defaultdict(dict)
 
-    for part, insts in fsics.items():
+    for part in sorted(fsics):
+        insts = fsics[part]
         remaining_in_chunk -= 1
-        for inst in insts:
+        for inst in sorted(insts):
             if remaining_in_chunk <= 0:
                 if current_chunk:
                     chunked_fsics.append(dict(current_chunk))

--- a/morango/models/fsic_utils.py
+++ b/morango/models/fsic_utils.py
@@ -58,6 +58,24 @@ def remove_redundant_instance_counters(raw_fsic):
                         del sub_dict[inst]
 
 
+def _add_filter_partitions(fsic, sync_filter):
+    """
+    Add the filter partitions to the FSIC dict.
+    """
+    for partition in sync_filter:
+        if partition not in fsic:
+            fsic[partition] = {}
+
+
+def _remove_empty_partitions(fsic):
+    """
+    Remove any partitions that are empty from the fsic dict.
+    """
+    for partition in list(fsic.keys()):
+        if not fsic[partition]:
+            del fsic[partition]
+
+
 def expand_fsic_for_use(raw_fsic, sync_filter):
     """
     Convert the raw FSIC format from the wire into a format usable for filtering, by propagating super partition counts
@@ -67,10 +85,8 @@ def expand_fsic_for_use(raw_fsic, sync_filter):
     assert "sub" in raw_fsic
     raw_fsic = raw_fsic.copy()
 
-    # ensure that the subpartition list includes all the filter partitions
-    for partition in sync_filter:
-        if partition not in raw_fsic["sub"]:
-            raw_fsic["sub"][partition] = {}
+    # ensure that the subpartition list includes all the filter partitions    
+    _add_filter_partitions(raw_fsic["sub"], sync_filter)
 
     # get a list of any subpartitions that are subordinate to other subpartitions
     subordinates = _get_sub_partitions(raw_fsic["sub"].keys())
@@ -89,9 +105,7 @@ def expand_fsic_for_use(raw_fsic, sync_filter):
                         sub_fsic[instance] = counter
 
     # remove any empty subpartitions
-    for sub_part in list(raw_fsic["sub"].keys()):
-        if not raw_fsic["sub"][sub_part]:
-            del raw_fsic["sub"][sub_part]
+    _remove_empty_partitions(raw_fsic["sub"])
 
     return raw_fsic["sub"]
 

--- a/morango/models/fsic_utils.py
+++ b/morango/models/fsic_utils.py
@@ -155,3 +155,33 @@ def calculate_directional_fsic_diff_v2(fsic1, fsic2):
                 result[part][inst] = receiving_counter
 
     return dict(result)
+
+
+def chunk_fsic_v2(fsics, chunk_size):
+    """
+    Split FSIC v2 dict into chunks with maximum partitions + instances of chunk_size.
+
+    :param fsic: dict containing FSIC v2's
+    :param chunk_size: size of chunks to split into
+    :return: list of dicts containing FSIC v2's
+    """
+
+    remaining_in_chunk = chunk_size
+
+    chunked_fsics = []
+    current_chunk = defaultdict(dict)
+
+    for part, insts in fsics.items():
+        remaining_in_chunk -= 1
+        for inst in insts:
+            if remaining_in_chunk <= 0:
+                if current_chunk:
+                    chunked_fsics.append(dict(current_chunk))
+                current_chunk = defaultdict(dict)
+                remaining_in_chunk = chunk_size - 1
+            current_chunk[part][inst] = insts[inst]
+            remaining_in_chunk -= 1
+    if current_chunk:
+        chunked_fsics.append(dict(current_chunk))
+
+    return chunked_fsics

--- a/morango/models/fsic_utils.py
+++ b/morango/models/fsic_utils.py
@@ -66,15 +66,15 @@ def expand_fsic_for_use(raw_fsic, sync_filter):
     assert "super" in raw_fsic
     assert "sub" in raw_fsic
     raw_fsic = raw_fsic.copy()
-    
+
     # ensure that the subpartition list includes all the filter partitions
     for partition in sync_filter:
         if partition not in raw_fsic["sub"]:
             raw_fsic["sub"][partition] = {}
-    
+
     # get a list of any subpartitions that are subordinate to other subpartitions
     subordinates = _get_sub_partitions(raw_fsic["sub"].keys())
-    
+
     # propagate the super partition counts down into sub-partitions
     for sub_part, sub_fsic in raw_fsic["sub"].items():
         # skip any partitions that are subordinate to another sub-partition
@@ -87,12 +87,12 @@ def expand_fsic_for_use(raw_fsic, sync_filter):
                 for instance, counter in super_fsic.items():
                     if counter > sub_fsic.get(instance, 0):
                         sub_fsic[instance] = counter
-    
+
     # remove any empty subpartitions
     for sub_part in list(raw_fsic["sub"].keys()):
         if not raw_fsic["sub"][sub_part]:
             del raw_fsic["sub"][sub_part]
-    
+
     return raw_fsic["sub"]
 
 

--- a/morango/sync/operations.py
+++ b/morango/sync/operations.py
@@ -545,12 +545,12 @@ def _queue_into_buffer_v2(transfersession):
     assert "super" in client_fsic
 
     # ensure that the partitions in the FSICs are under the current filter, before using them
-    for partition in itertools.chain(server_fsic["sub"].keys(), client_fsic["sub"]):
+    for partition in itertools.chain(server_fsic["sub"].keys(), client_fsic["sub"].keys()):
         if partition not in sync_filter:
             raise MorangoInvalidFSICPartition("Partition '{}' is not in filter".format(partition))
 
-    server_fsic = expand_fsic_for_use(server_fsic)
-    client_fsic = expand_fsic_for_use(client_fsic)
+    server_fsic = expand_fsic_for_use(server_fsic, sync_filter)
+    client_fsic = expand_fsic_for_use(client_fsic, sync_filter)
 
     if transfersession.push:
         fsics = calculate_directional_fsic_diff_v2(client_fsic, server_fsic)

--- a/morango/sync/operations.py
+++ b/morango/sync/operations.py
@@ -37,6 +37,7 @@ from morango.models.core import TransferSession
 from morango.models.fsic_utils import (
     calculate_directional_fsic_diff,
     calculate_directional_fsic_diff_v2,
+    chunk_fsic_v2,
     expand_fsic_for_use,
 )
 from morango.registry import syncable_models
@@ -446,7 +447,6 @@ def _queue_into_buffer_v1(transfersession):
     i = 0
     chunk = fsics[:chunk_size]
     select_buffers = []
-    select_rmc_buffers = []
 
     while chunk:
         # create condition for all push FSICs where instance_ids are equal, but internal counters are higher than
@@ -483,23 +483,20 @@ def _queue_into_buffer_v1(transfersession):
                 store=Store._meta.db_table,
             )
         )
-        # take all record max counters that are foreign keyed onto store models, which were queued into the buffer
-        select_rmc_buffers.append(
-            """SELECT instance_id, counter, CAST ('{transfer_session_id}' AS {transfer_session_id_type}), store_model_id
-               FROM {record_max_counter} AS rmc
-               INNER JOIN {outgoing_buffer} AS buffer ON rmc.store_model_id = buffer.model_uuid
-               WHERE buffer.transfer_session_id = '{transfer_session_id}'
-            """.format(
-                transfer_session_id=transfersession.id,
-                transfer_session_id_type=TransferSession._meta.pk.rel_db_type(
-                    connection
-                ),
-                record_max_counter=RecordMaxCounter._meta.db_table,
-                outgoing_buffer=Buffer._meta.db_table,
-            )
-        )
         i += chunk_size
         chunk = fsics[i : i + chunk_size]
+
+    # take all record max counters that are foreign keyed onto store models, which were queued into the buffer
+    select_rmc_buffer_query = """SELECT instance_id, counter, CAST ('{transfer_session_id}' AS {transfer_session_id_type}), store_model_id
+            FROM {record_max_counter} AS rmc
+            INNER JOIN {outgoing_buffer} AS buffer ON rmc.store_model_id = buffer.model_uuid
+            WHERE buffer.transfer_session_id = '{transfer_session_id}'
+        """.format(
+        transfer_session_id=transfersession.id,
+        transfer_session_id_type=TransferSession._meta.pk.rel_db_type(connection),
+        record_max_counter=RecordMaxCounter._meta.db_table,
+        outgoing_buffer=Buffer._meta.db_table,
+    )
 
     with connection.cursor() as cursor:
         cursor.execute(
@@ -519,13 +516,13 @@ def _queue_into_buffer_v1(transfersession):
                {select}
             """.format(
                 outgoing_rmcb=RecordMaxCounterBuffer._meta.db_table,
-                select=" UNION ".join(select_rmc_buffers),
+                select=select_rmc_buffer_query,
             )
         )
 
 
 @transaction.atomic(using=USING_DB)
-def _queue_into_buffer_v2(transfersession):
+def _queue_into_buffer_v2(transfersession, chunk_size=200):
     """
     Takes a chunk of data from the store to be put into the buffer to be sent to another morango instance.
 
@@ -545,9 +542,13 @@ def _queue_into_buffer_v2(transfersession):
     assert "super" in client_fsic
 
     # ensure that the partitions in the FSICs are under the current filter, before using them
-    for partition in itertools.chain(server_fsic["sub"].keys(), client_fsic["sub"].keys()):
+    for partition in itertools.chain(
+        server_fsic["sub"].keys(), client_fsic["sub"].keys()
+    ):
         if partition not in sync_filter:
-            raise MorangoInvalidFSICPartition("Partition '{}' is not in filter".format(partition))
+            raise MorangoInvalidFSICPartition(
+                "Partition '{}' is not in filter".format(partition)
+            )
 
     server_fsic = expand_fsic_for_use(server_fsic, sync_filter)
     client_fsic = expand_fsic_for_use(client_fsic, sync_filter)
@@ -563,10 +564,33 @@ def _queue_into_buffer_v2(transfersession):
 
     profile_condition = ["profile = '{}'".format(transfersession.sync_session.profile)]
 
-    # create condition for filtering by partitions
-    partition_conditions = []
-    for part, insts in fsics.items():
-        if insts:
+    fsics_len = sum(len(fsics[part]) for part in fsics) + len(fsics)
+    # subtract one because when partitions overflow chunks they add up to an extra item per chunk
+    fsics_limit = chunk_size * (SQL_UNION_MAX - 1)
+
+    if fsics_len >= fsics_limit:
+        raise MorangoLimitExceeded(
+            "Limit of {limit} instances + partitions exceeded with {actual}".format(
+                limit=fsics_limit, actual=fsics_len
+            )
+        )
+
+    # if needed, split the fsics into chunks
+    if fsics_len > chunk_size:
+        chunked_fsics = chunk_fsic_v2(fsics, chunk_size)
+    else:
+        chunked_fsics = [fsics]
+
+    select_buffers = []
+
+    for fsic_chunk in chunked_fsics:
+
+        # create condition for filtering by partitions
+        partition_conditions = []
+        for part, insts in fsic_chunk.items():
+            if not insts:
+                continue
+
             partition_conditions.append(
                 "partition LIKE '{}%' AND (".format(part)
                 + _join_with_logical_operator(
@@ -580,39 +604,41 @@ def _queue_into_buffer_v2(transfersession):
                 )
                 + ")"
             )
-    partition_conditions = [_join_with_logical_operator(partition_conditions, "OR")]
 
-    # combine conditions and filter by profile
-    where_condition = _join_with_logical_operator(
-        profile_condition + partition_conditions, "AND"
-    )
+        partition_conditions = [_join_with_logical_operator(partition_conditions, "OR")]
 
-    # execute raw sql to take all records that match condition, to be put into buffer for transfer
-    select_buffer_query = (
-        """SELECT DISTINCT
-                id, serialized, deleted, last_saved_instance, last_saved_counter, hard_deleted, model_name, profile,
-                partition, source_id, conflicting_serialized_data,
-                CAST ('{transfer_session_id}' AS {transfer_session_id_type}), _self_ref_fk
-            FROM {store} WHERE {condition}
-        """.format(
-            transfer_session_id=transfersession.id,
-            transfer_session_id_type=TransferSession._meta.pk.rel_db_type(connection),
-            condition=where_condition,
-            store=Store._meta.db_table,
+        # combine conditions and filter by profile
+        where_condition = _join_with_logical_operator(
+            profile_condition + partition_conditions, "AND"
         )
-    )
+
+        # execute raw sql to take all records that match condition, to be put into buffer for transfer
+        select_buffers.append(
+            """SELECT DISTINCT
+                    id, serialized, deleted, last_saved_instance, last_saved_counter, hard_deleted, model_name, profile,
+                    partition, source_id, conflicting_serialized_data,
+                    CAST ('{transfer_session_id}' AS {transfer_session_id_type}), _self_ref_fk
+                FROM {store} WHERE {condition}
+            """.format(
+                transfer_session_id=transfersession.id,
+                transfer_session_id_type=TransferSession._meta.pk.rel_db_type(
+                    connection
+                ),
+                condition=where_condition,
+                store=Store._meta.db_table,
+            )
+        )
+
     # take all record max counters that are foreign keyed onto store models, which were queued into the buffer
-    select_rmc_buffer_query = (
-        """SELECT instance_id, counter, CAST ('{transfer_session_id}' AS {transfer_session_id_type}), store_model_id
+    select_rmc_buffer_query = """SELECT instance_id, counter, CAST ('{transfer_session_id}' AS {transfer_session_id_type}), store_model_id
             FROM {record_max_counter} AS rmc
             INNER JOIN {outgoing_buffer} AS buffer ON rmc.store_model_id = buffer.model_uuid
             WHERE buffer.transfer_session_id = '{transfer_session_id}'
         """.format(
-            transfer_session_id=transfersession.id,
-            transfer_session_id_type=TransferSession._meta.pk.rel_db_type(connection),
-            record_max_counter=RecordMaxCounter._meta.db_table,
-            outgoing_buffer=Buffer._meta.db_table,
-        )
+        transfer_session_id=transfersession.id,
+        transfer_session_id_type=TransferSession._meta.pk.rel_db_type(connection),
+        record_max_counter=RecordMaxCounter._meta.db_table,
+        outgoing_buffer=Buffer._meta.db_table,
     )
 
     with connection.cursor() as cursor:
@@ -624,7 +650,7 @@ def _queue_into_buffer_v2(transfersession):
                {select}
             """.format(
                 outgoing_buffer=Buffer._meta.db_table,
-                select=select_buffer_query,
+                select=" UNION ".join(select_buffers),
             )
         )
         cursor.execute(

--- a/morango/sync/operations.py
+++ b/morango/sync/operations.py
@@ -614,7 +614,7 @@ def _queue_into_buffer_v2(transfersession, chunk_size=200):
 
         # execute raw sql to take all records that match condition, to be put into buffer for transfer
         select_buffers.append(
-            """SELECT DISTINCT
+            """SELECT
                     id, serialized, deleted, last_saved_instance, last_saved_counter, hard_deleted, model_name, profile,
                     partition, source_id, conflicting_serialized_data,
                     CAST ('{transfer_session_id}' AS {transfer_session_id_type}), _self_ref_fk

--- a/tests/testapp/tests/models/test_fsic_utils.py
+++ b/tests/testapp/tests/models/test_fsic_utils.py
@@ -9,44 +9,55 @@ class TestFSICUtils(TestCase):
     def test_expand_fsic_for_use(self):
         source_fsic = {
             "super": {
-                "p": {
+                "r": {
                     "a": 5,
                     "b": 3,
                     "c": 7,
                 },
+                "q": {
+                    "f": 5,
+                }
             },
             "sub": {
-                "p1": {
+                "rp1": {
                     "a": 1,
                     "b": 9,
                     "d": 2,
                 },
-                "p1i": {
+                "rp1i": {
                     "e": 5,
                 },
-                "p2i": {
+                "rp2i": {
                     "e": 5,
+                },
+                "tt": {  # this will be removed, as it's empty
                 },
             },
         }
         expected_fsic = {
-            "p1": {
+            "rp1": {
                 "a": 5,  # from super, because it was larger
                 "b": 9,  # from sub, because it was larger
                 "c": 7,  # from super, because it didn't exist in sub
                 "d": 2,  # from sub, because it didn't exist in super
             },
-            "p1i": {  # only instance here, because others from super were covered by p1
-                "e": 5, 
+            "rp1i": {  # only instance here, because others from super were covered by p1
+                "e": 5,
             },
-            "p2i": {  # but no prefix in sub for this one, so it does inherit from super
+            "rp2": {  # this one was inserted here, because it's in the filter, and inherits from super
                 "a": 5,
                 "b": 3,
                 "c": 7,
+            },
+            "rp2i": {  # this doesn't inherit, because it's a suffix of the inserted "rp2"
                 "e": 5,
             },
+            "q1": {
+                "f": 5,  # inserted here, because it's in the filter, and inherits from super
+            },
         }
-        self.assertEqual(expand_fsic_for_use(source_fsic), expected_fsic)
+        sync_filter = ["rp1", "rp2", "q1", "t"]
+        self.assertEqual(expand_fsic_for_use(source_fsic, sync_filter), expected_fsic)
 
     def test_remove_redundant_instance_counters(self):
         source_fsic = {


### PR DESCRIPTION
## Summary

When implementing `_queue_into_buffer_v2` for queuing records with the new FSIC v2, the first version didn't include chunking (and then UNIONing) of SELECT statements, to avoid "Expression tree is too large" errors. This PR builds on https://github.com/learningequality/morango/pull/146 (which should be merged first, to make this one easier to review) by adding back chunking logic.

## TODO

- [x] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance

It basically splits the expanded FSIC into chunks with max partitions + instances of `chunk_size`, and then does the same logic as before to create a SELECT statement for each FSIC chunk, then does a UNION on those as in the old chunking approach.

It also makes a tweak to the chunking code in the v1 queuing operation, after noting that we don't need to create a separate SELECT and then UNION for the RMBC queries, since they were all identical.