### PR TITLE
Add ORDER BY to buffer's API viewset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 List of the most important changes for each release.
 
+## 0.6.9
+- Fixes un-ordered selection of buffers during sync which can allow duplicates to be synced with PostgreSQL backends
+
 ## 0.6.8
 - Fixes subset syncing issues by introducing new FSIC v2 format
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.4'
+
+services:
+  postgres:
+    image: postgres:9.6
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: default
+    command: "postgres -c log_statement=all -c log_line_prefix='%t %d '"
+    volumes:
+      - morango-postgres:/var/lib/postgresql/data
+volumes:
+  morango-postgres:

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.8"
+__version__ = "0.6.9"

--- a/morango/api/viewsets.py
+++ b/morango/api/viewsets.py
@@ -501,7 +501,7 @@ class BufferViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 
     def get_queryset(self):
         session_id = self.request.query_params["transfer_session_id"]
-        return Buffer.objects.filter(transfer_session_id=session_id)
+        return Buffer.objects.filter(transfer_session_id=session_id).order_by("pk")
 
 
 class MorangoInfoViewSet(viewsets.ViewSet):


### PR DESCRIPTION
## Summary
- Adds regression test for the `ORDER BY` issue on the buffers API
- Adds `docker-compose` config and updates `Makefile` to support running all tests with postgres using easy single command
- Buffers during push sync are already ordered correctly

## TODO
- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance
- See [this PR](https://github.com/learningequality/morango/pull/149) for failing test prior to changes.
- To run tests with Postgres: `make test-with-postgres` (must have `docker-compose`)

## Issues addressed
Resolves https://github.com/learningequality/morango/issues/148
