### PR TITLE
Eliminate extraneous queries for transfer session in buffer serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 List of the most important changes for each release.
 
+## 0.6.11
+- Added deferred processing of foreign keys to allow bulk processing and to improve performance.
+- Eliminated extraneous SQL queries for the transfer session when querying for buffers.
+
 ## 0.6.10
 - Fixes Django migration issue introduced in 0.6.7 allowing nullable fields with PostgreSQL backends
 

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.10"
+__version__ = "0.6.11"

--- a/morango/models/core.py
+++ b/morango/models/core.py
@@ -525,7 +525,7 @@ class Buffer(AbstractStore):
 
     def rmcb_list(self):
         return RecordMaxCounterBuffer.objects.filter(
-            model_uuid=self.model_uuid, transfer_session=self.transfer_session
+            model_uuid=self.model_uuid, transfer_session_id=self.transfer_session_id
         )
 
 

--- a/tests/testapp/tests/test_api.py
+++ b/tests/testapp/tests/test_api.py
@@ -1067,7 +1067,7 @@ class BufferEndpointTestCase(CertificateTestCaseMixin, APITestCase):
         with CaptureQueriesContext(connection) as ctx:
             result = BufferSerializer(instance=buffers[0]).data
             for q in ctx.captured_queries:
-                self.assertNotRegexpMatches(q["sql"], 'morango_transfersession')
+                self.assertFalse('morango_transfersession' in q['sql'])
 
     def test_pull_valid_buffer_list(self):
 


### PR DESCRIPTION
## Summary
- We noticed memory spikes during buffers' API requests
- Turns out we were excessively querying for the transfer session when serializing buffers

## TODO

- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

List the issues solved or partly solved by the PR

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)
