### PR TITLE
Replace serializable transaction isolation with advisory locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 List of the most important changes for each release.
 
+## 0.6.12
+- Replace serializable transaction isolation using a separate DB connection for Postgres with advisory locking.
+
 ## 0.6.11
 - Added deferred processing of foreign keys to allow bulk processing and to improve performance.
 - Eliminated extraneous SQL queries for the transfer session when querying for buffers.

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.11"
+__version__ = "0.6.12"

--- a/morango/constants/settings.py
+++ b/morango/constants/settings.py
@@ -43,3 +43,4 @@ MORANGO_CLEANUP_OPERATIONS = (
     "morango.sync.operations:CleanupOperation",
     "morango.sync.operations:NetworkCleanupOperation",
 )
+MORANGO_TEST_POSTGRESQL = False

--- a/morango/sync/backends/base.py
+++ b/morango/sync/backends/base.py
@@ -176,3 +176,22 @@ class BaseSQLWrapper(object):
             name=name, fields=", ".join(field_sqls)
         )
         cursor.execute(sql, fields_params)
+
+    def _lock_all_partitions(self, shared=False):
+        """
+        Execute a lock within the database for all partitions, if the backend supports it. The lock
+        should block until acquired
+
+        :param shared: Whether or not the lock is exclusive or shared
+        """
+        pass
+
+    def _lock_partition(self, partition, shared=False):
+        """
+        Execute a lock within the database for a specific partition, if the database supports it.
+        The lock should block until acquired
+
+        :param partition: The partition prefix string to lock
+        :param shared: Whether or not the lock is exclusive or shared
+        """
+        pass

--- a/morango/sync/backends/base.py
+++ b/morango/sync/backends/base.py
@@ -10,6 +10,10 @@ class BaseSQLWrapper(object):
     def __init__(self, connection):
         self.connection = connection
 
+    def _set_transaction_repeatable_read(self):
+        """Set the current transaction isolation level"""
+        pass
+
     def _create_placeholder_list(self, fields, db_values):
         # number of rows to update
         num_of_rows = len(db_values) // len(fields)

--- a/morango/sync/backends/postgres.py
+++ b/morango/sync/backends/postgres.py
@@ -324,6 +324,11 @@ class SQLWrapper(BaseSQLWrapper):
         :param partition: The partition prefix string to lock
         :param shared: Whether the lock is exclusive or shared
         """
+        # first we open a shared lock on all partitions, so that we don't interfere with concurrent
+        # locks on all partitions or operations that could attempt to open a lock on all partitions
+        # while we've locked only some partitions
+        self._lock_all_partitions(shared=True)
+
         # Postgres advisory locks use integers, so we have to convert the partition string into
         # an integer. To do this we use crc32, which returns an unsigned integer. When using two
         # keys for advisory locks, the two keys are signed integers, so we have to adjust the crc32

--- a/morango/sync/controller.py
+++ b/morango/sync/controller.py
@@ -4,7 +4,6 @@ from time import sleep
 from morango.constants import transfer_stages
 from morango.constants import transfer_statuses
 from morango.registry import session_middleware
-
 from morango.sync.operations import _deserialize_from_store
 from morango.sync.operations import _serialize_into_store
 from morango.sync.operations import OperationLogger

--- a/morango/sync/operations.py
+++ b/morango/sync/operations.py
@@ -4,6 +4,7 @@ import json
 import logging
 import uuid
 from collections import defaultdict
+from contextlib import contextmanager
 
 from django.core import exceptions
 from django.core.serializers.json import DjangoJSONEncoder
@@ -89,6 +90,23 @@ def _self_referential_fk(model):
     return None
 
 
+@contextmanager
+def _begin_transaction(sync_filter, shared_lock=False):
+    """
+    Starts a transaction, sets the transaction isolation level to repeatable read, and locks
+    affected partitions
+
+    :type sync_filter: morango.models.certificates.Filter|None
+    :type shared_lock: bool
+    """
+    # we can't allow django to create savepoints because we can't change the isolation level within
+    # subtransactions (after a savepoint has been created)
+    with transaction.atomic(savepoint=False):
+        DBBackend._set_transaction_repeatable_read()
+        lock_partitions(DBBackend, sync_filter=sync_filter, shared=shared_lock)
+        yield
+
+
 def _serialize_into_store(profile, filter=None):
     """
     Takes data from app layer and serializes the models into the store.
@@ -103,9 +121,7 @@ def _serialize_into_store(profile, filter=None):
     # ensure that we write and retrieve the counter in one go for consistency
     current_id = InstanceIDModel.get_current_instance_and_increment_counter()
 
-    with transaction.atomic():
-        lock_partitions(DBBackend, sync_filter=filter, shared=False)
-
+    with _begin_transaction(filter):
         # create Q objects for filtering by prefixes
         prefix_condition = None
         if filter:
@@ -420,9 +436,7 @@ def _deserialize_from_store(profile, skip_erroring=False, filter=None):
     excluded_list = []
     deleted_list = []
 
-    with transaction.atomic():
-        lock_partitions(DBBackend, sync_filter=filter, shared=False)
-
+    with _begin_transaction(filter):
         # iterate through classes which are in foreign key dependency order
         for model in syncable_models.get_models(profile):
             deferred_fks = defaultdict(list)
@@ -582,7 +596,6 @@ def _deserialize_from_store(profile, skip_erroring=False, filter=None):
                 ).update(dirty_bit=False)
 
 
-@transaction.atomic()
 def _queue_into_buffer_v1(transfersession):
     """
     Takes a chunk of data from the store to be put into the buffer to be sent to another morango instance. This is the legacy
@@ -593,119 +606,117 @@ def _queue_into_buffer_v1(transfersession):
     as well as the partition for the data we are syncing.
     """
     filter_prefixes = Filter(transfersession.filter)
-    server_fsic = json.loads(transfersession.server_fsic)
-    client_fsic = json.loads(transfersession.client_fsic)
+    with _begin_transaction(filter_prefixes, shared_lock=True):
+        server_fsic = json.loads(transfersession.server_fsic)
+        client_fsic = json.loads(transfersession.client_fsic)
 
-    lock_partitions(DBBackend, sync_filter=filter_prefixes, shared=True)
+        if transfersession.push:
+            fsics = calculate_directional_fsic_diff(client_fsic, server_fsic)
+        else:
+            fsics = calculate_directional_fsic_diff(server_fsic, client_fsic)
 
-    if transfersession.push:
-        fsics = calculate_directional_fsic_diff(client_fsic, server_fsic)
-    else:
-        fsics = calculate_directional_fsic_diff(server_fsic, client_fsic)
+        # if fsics are identical or receiving end has newer data, then there is nothing to queue
+        if not fsics:
+            return
 
-    # if fsics are identical or receiving end has newer data, then there is nothing to queue
-    if not fsics:
-        return
+        profile_condition = ["profile = '{}'".format(transfersession.sync_session.profile)]
+        partition_conditions = []
+        # create condition for filtering by partitions
+        for prefix in filter_prefixes:
+            partition_conditions += ["partition LIKE '{}%'".format(prefix)]
+        if filter_prefixes:
+            partition_conditions = [_join_with_logical_operator(partition_conditions, "OR")]
 
-    profile_condition = ["profile = '{}'".format(transfersession.sync_session.profile)]
-    partition_conditions = []
-    # create condition for filtering by partitions
-    for prefix in filter_prefixes:
-        partition_conditions += ["partition LIKE '{}%'".format(prefix)]
-    if filter_prefixes:
-        partition_conditions = [_join_with_logical_operator(partition_conditions, "OR")]
+        chunk_size = 200
+        fsics = list(fsics.items())
+        fsics_len = len(fsics)
+        fsics_limit = chunk_size * SQL_UNION_MAX
 
-    chunk_size = 200
-    fsics = list(fsics.items())
-    fsics_len = len(fsics)
-    fsics_limit = chunk_size * SQL_UNION_MAX
-
-    if fsics_len >= fsics_limit:
-        raise MorangoLimitExceeded(
-            "Limit of {limit} instance counters exceeded with {actual}".format(
-                limit=fsics_limit, actual=fsics_len
+        if fsics_len >= fsics_limit:
+            raise MorangoLimitExceeded(
+                "Limit of {limit} instance counters exceeded with {actual}".format(
+                    limit=fsics_limit, actual=fsics_len
+                )
             )
-        )
 
-    # chunk fsics creating multiple SQL selects which will be unioned before insert
-    i = 0
-    chunk = fsics[:chunk_size]
-    select_buffers = []
+        # chunk fsics creating multiple SQL selects which will be unioned before insert
+        i = 0
+        chunk = fsics[:chunk_size]
+        select_buffers = []
 
-    while chunk:
-        # create condition for all push FSICs where instance_ids are equal, but internal counters are higher than
-        # FSICs counters
-        last_saved_by_conditions = [
-            "(last_saved_instance = '{0}' AND last_saved_counter > {1})".format(
-                instance, counter
-            )
-            for instance, counter in chunk
-        ]
-        if last_saved_by_conditions:
+        while chunk:
+            # create condition for all push FSICs where instance_ids are equal, but internal counters are higher than
+            # FSICs counters
             last_saved_by_conditions = [
-                _join_with_logical_operator(last_saved_by_conditions, "OR")
+                "(last_saved_instance = '{0}' AND last_saved_counter > {1})".format(
+                    instance, counter
+                )
+                for instance, counter in chunk
             ]
+            if last_saved_by_conditions:
+                last_saved_by_conditions = [
+                    _join_with_logical_operator(last_saved_by_conditions, "OR")
+                ]
 
-        # combine conditions and filter by profile
-        where_condition = _join_with_logical_operator(
-            profile_condition + last_saved_by_conditions + partition_conditions, "AND"
-        )
-
-        # execute raw sql to take all records that match condition, to be put into buffer for transfer
-        select_buffers.append(
-            """SELECT
-                   id, serialized, deleted, last_saved_instance, last_saved_counter, hard_deleted, model_name, profile,
-                   partition, source_id, conflicting_serialized_data,
-                   CAST ('{transfer_session_id}' AS {transfer_session_id_type}), _self_ref_fk
-               FROM {store} WHERE {condition}
-            """.format(
-                transfer_session_id=transfersession.id,
-                transfer_session_id_type=TransferSession._meta.pk.rel_db_type(
-                    connection
-                ),
-                condition=where_condition,
-                store=Store._meta.db_table,
+            # combine conditions and filter by profile
+            where_condition = _join_with_logical_operator(
+                profile_condition + last_saved_by_conditions + partition_conditions, "AND"
             )
-        )
-        i += chunk_size
-        chunk = fsics[i : i + chunk_size]
 
-    # take all record max counters that are foreign keyed onto store models, which were queued into the buffer
-    select_rmc_buffer_query = """SELECT instance_id, counter, CAST ('{transfer_session_id}' AS {transfer_session_id_type}), store_model_id
-            FROM {record_max_counter} AS rmc
-            INNER JOIN {outgoing_buffer} AS buffer ON rmc.store_model_id = buffer.model_uuid
-            WHERE buffer.transfer_session_id = '{transfer_session_id}'
-        """.format(
-        transfer_session_id=transfersession.id,
-        transfer_session_id_type=TransferSession._meta.pk.rel_db_type(connection),
-        record_max_counter=RecordMaxCounter._meta.db_table,
-        outgoing_buffer=Buffer._meta.db_table,
-    )
-
-    with connection.cursor() as cursor:
-        cursor.execute(
-            """INSERT INTO {outgoing_buffer}
-               (model_uuid, serialized, deleted, last_saved_instance, last_saved_counter,
-               hard_deleted, model_name, profile, partition, source_id, conflicting_serialized_data,
-               transfer_session_id, _self_ref_fk)
-               {select}
-            """.format(
-                outgoing_buffer=Buffer._meta.db_table,
-                select=" UNION ".join(select_buffers),
+            # execute raw sql to take all records that match condition, to be put into buffer for transfer
+            select_buffers.append(
+                """SELECT
+                       id, serialized, deleted, last_saved_instance, last_saved_counter, hard_deleted, model_name, profile,
+                       partition, source_id, conflicting_serialized_data,
+                       CAST ('{transfer_session_id}' AS {transfer_session_id_type}), _self_ref_fk
+                   FROM {store} WHERE {condition}
+                """.format(
+                    transfer_session_id=transfersession.id,
+                    transfer_session_id_type=TransferSession._meta.pk.rel_db_type(
+                        connection
+                    ),
+                    condition=where_condition,
+                    store=Store._meta.db_table,
+                )
             )
-        )
-        cursor.execute(
-            """INSERT INTO {outgoing_rmcb}
-               (instance_id, counter, transfer_session_id, model_uuid)
-               {select}
+            i += chunk_size
+            chunk = fsics[i : i + chunk_size]
+
+        # take all record max counters that are foreign keyed onto store models, which were queued into the buffer
+        select_rmc_buffer_query = """SELECT instance_id, counter, CAST ('{transfer_session_id}' AS {transfer_session_id_type}), store_model_id
+                FROM {record_max_counter} AS rmc
+                INNER JOIN {outgoing_buffer} AS buffer ON rmc.store_model_id = buffer.model_uuid
+                WHERE buffer.transfer_session_id = '{transfer_session_id}'
             """.format(
-                outgoing_rmcb=RecordMaxCounterBuffer._meta.db_table,
-                select=select_rmc_buffer_query,
-            )
+            transfer_session_id=transfersession.id,
+            transfer_session_id_type=TransferSession._meta.pk.rel_db_type(connection),
+            record_max_counter=RecordMaxCounter._meta.db_table,
+            outgoing_buffer=Buffer._meta.db_table,
         )
 
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """INSERT INTO {outgoing_buffer}
+                   (model_uuid, serialized, deleted, last_saved_instance, last_saved_counter,
+                   hard_deleted, model_name, profile, partition, source_id, conflicting_serialized_data,
+                   transfer_session_id, _self_ref_fk)
+                   {select}
+                """.format(
+                    outgoing_buffer=Buffer._meta.db_table,
+                    select=" UNION ".join(select_buffers),
+                )
+            )
+            cursor.execute(
+                """INSERT INTO {outgoing_rmcb}
+                   (instance_id, counter, transfer_session_id, model_uuid)
+                   {select}
+                """.format(
+                    outgoing_rmcb=RecordMaxCounterBuffer._meta.db_table,
+                    select=select_rmc_buffer_query,
+                )
+            )
 
-@transaction.atomic()
+
 def _queue_into_buffer_v2(transfersession, chunk_size=200):
     """
     Takes a chunk of data from the store to be put into the buffer to be sent to another morango instance.
@@ -717,140 +728,138 @@ def _queue_into_buffer_v2(transfersession, chunk_size=200):
     We use raw sql queries to place data in the buffer and the record max counter buffer, which matches the conditions of the FSIC.
     """
     sync_filter = Filter(transfersession.filter)
-    server_fsic = json.loads(transfersession.server_fsic)
-    client_fsic = json.loads(transfersession.client_fsic)
+    with _begin_transaction(sync_filter, shared_lock=True):
+        server_fsic = json.loads(transfersession.server_fsic)
+        client_fsic = json.loads(transfersession.client_fsic)
 
-    lock_partitions(DBBackend, sync_filter=sync_filter, shared=True)
+        assert "sub" in server_fsic
+        assert "super" in server_fsic
+        assert "sub" in client_fsic
+        assert "super" in client_fsic
 
-    assert "sub" in server_fsic
-    assert "super" in server_fsic
-    assert "sub" in client_fsic
-    assert "super" in client_fsic
-
-    # ensure that the partitions in the FSICs are under the current filter, before using them
-    for partition in itertools.chain(
-        server_fsic["sub"].keys(), client_fsic["sub"].keys()
-    ):
-        if partition not in sync_filter:
-            raise MorangoInvalidFSICPartition(
-                "Partition '{}' is not in filter".format(partition)
-            )
-
-    server_fsic = expand_fsic_for_use(server_fsic, sync_filter)
-    client_fsic = expand_fsic_for_use(client_fsic, sync_filter)
-
-    if transfersession.push:
-        fsics = calculate_directional_fsic_diff_v2(client_fsic, server_fsic)
-    else:
-        fsics = calculate_directional_fsic_diff_v2(server_fsic, client_fsic)
-
-    # if fsics are identical or receiving end has newer data, then there is nothing to queue
-    if not fsics:
-        return
-
-    profile_condition = ["profile = '{}'".format(transfersession.sync_session.profile)]
-
-    fsics_len = sum(len(fsics[part]) for part in fsics) + len(fsics)
-    # subtract one because when partitions overflow chunks they add up to an extra item per chunk
-    fsics_limit = chunk_size * (SQL_UNION_MAX - 1)
-
-    if fsics_len >= fsics_limit:
-        raise MorangoLimitExceeded(
-            "Limit of {limit} instances + partitions exceeded with {actual}".format(
-                limit=fsics_limit, actual=fsics_len
-            )
-        )
-
-    # if needed, split the fsics into chunks
-    if fsics_len > chunk_size:
-        chunked_fsics = chunk_fsic_v2(fsics, chunk_size)
-    else:
-        chunked_fsics = [fsics]
-
-    select_buffers = []
-
-    for fsic_chunk in chunked_fsics:
-
-        # create condition for filtering by partitions
-        partition_conditions = []
-        for part, insts in fsic_chunk.items():
-            if not insts:
-                continue
-
-            partition_conditions.append(
-                "partition LIKE '{}%' AND (".format(part)
-                + _join_with_logical_operator(
-                    [
-                        "(last_saved_instance = '{}' AND last_saved_counter > {})".format(
-                            inst, counter
-                        )
-                        for inst, counter in insts.items()
-                    ],
-                    "OR",
+        # ensure that the partitions in the FSICs are under the current filter, before using them
+        for partition in itertools.chain(
+            server_fsic["sub"].keys(), client_fsic["sub"].keys()
+        ):
+            if partition not in sync_filter:
+                raise MorangoInvalidFSICPartition(
+                    "Partition '{}' is not in filter".format(partition)
                 )
-                + ")"
+
+        server_fsic = expand_fsic_for_use(server_fsic, sync_filter)
+        client_fsic = expand_fsic_for_use(client_fsic, sync_filter)
+
+        if transfersession.push:
+            fsics = calculate_directional_fsic_diff_v2(client_fsic, server_fsic)
+        else:
+            fsics = calculate_directional_fsic_diff_v2(server_fsic, client_fsic)
+
+        # if fsics are identical or receiving end has newer data, then there is nothing to queue
+        if not fsics:
+            return
+
+        profile_condition = ["profile = '{}'".format(transfersession.sync_session.profile)]
+
+        fsics_len = sum(len(fsics[part]) for part in fsics) + len(fsics)
+        # subtract one because when partitions overflow chunks they add up to an extra item per chunk
+        fsics_limit = chunk_size * (SQL_UNION_MAX - 1)
+
+        if fsics_len >= fsics_limit:
+            raise MorangoLimitExceeded(
+                "Limit of {limit} instances + partitions exceeded with {actual}".format(
+                    limit=fsics_limit, actual=fsics_len
+                )
             )
 
-        partition_conditions = [_join_with_logical_operator(partition_conditions, "OR")]
+        # if needed, split the fsics into chunks
+        if fsics_len > chunk_size:
+            chunked_fsics = chunk_fsic_v2(fsics, chunk_size)
+        else:
+            chunked_fsics = [fsics]
 
-        # combine conditions and filter by profile
-        where_condition = _join_with_logical_operator(
-            profile_condition + partition_conditions, "AND"
-        )
+        select_buffers = []
 
-        # execute raw sql to take all records that match condition, to be put into buffer for transfer
-        select_buffers.append(
-            """SELECT
-                    id, serialized, deleted, last_saved_instance, last_saved_counter, hard_deleted, model_name, profile,
-                    partition, source_id, conflicting_serialized_data,
-                    CAST ('{transfer_session_id}' AS {transfer_session_id_type}), _self_ref_fk
-                FROM {store} WHERE {condition}
+        for fsic_chunk in chunked_fsics:
+
+            # create condition for filtering by partitions
+            partition_conditions = []
+            for part, insts in fsic_chunk.items():
+                if not insts:
+                    continue
+
+                partition_conditions.append(
+                    "partition LIKE '{}%' AND (".format(part)
+                    + _join_with_logical_operator(
+                        [
+                            "(last_saved_instance = '{}' AND last_saved_counter > {})".format(
+                                inst, counter
+                            )
+                            for inst, counter in insts.items()
+                        ],
+                        "OR",
+                    )
+                    + ")"
+                )
+
+            partition_conditions = [_join_with_logical_operator(partition_conditions, "OR")]
+
+            # combine conditions and filter by profile
+            where_condition = _join_with_logical_operator(
+                profile_condition + partition_conditions, "AND"
+            )
+
+            # execute raw sql to take all records that match condition, to be put into buffer for transfer
+            select_buffers.append(
+                """SELECT
+                        id, serialized, deleted, last_saved_instance, last_saved_counter, hard_deleted, model_name, profile,
+                        partition, source_id, conflicting_serialized_data,
+                        CAST ('{transfer_session_id}' AS {transfer_session_id_type}), _self_ref_fk
+                    FROM {store} WHERE {condition}
+                """.format(
+                    transfer_session_id=transfersession.id,
+                    transfer_session_id_type=TransferSession._meta.pk.rel_db_type(
+                        connection
+                    ),
+                    condition=where_condition,
+                    store=Store._meta.db_table,
+                )
+            )
+
+        # take all record max counters that are foreign keyed onto store models, which were queued into the buffer
+        select_rmc_buffer_query = """SELECT instance_id, counter, CAST ('{transfer_session_id}' AS {transfer_session_id_type}), store_model_id
+                FROM {record_max_counter} AS rmc
+                INNER JOIN {outgoing_buffer} AS buffer ON rmc.store_model_id = buffer.model_uuid
+                WHERE buffer.transfer_session_id = '{transfer_session_id}'
             """.format(
-                transfer_session_id=transfersession.id,
-                transfer_session_id_type=TransferSession._meta.pk.rel_db_type(
-                    connection
-                ),
-                condition=where_condition,
-                store=Store._meta.db_table,
-            )
+            transfer_session_id=transfersession.id,
+            transfer_session_id_type=TransferSession._meta.pk.rel_db_type(connection),
+            record_max_counter=RecordMaxCounter._meta.db_table,
+            outgoing_buffer=Buffer._meta.db_table,
         )
 
-    # take all record max counters that are foreign keyed onto store models, which were queued into the buffer
-    select_rmc_buffer_query = """SELECT instance_id, counter, CAST ('{transfer_session_id}' AS {transfer_session_id_type}), store_model_id
-            FROM {record_max_counter} AS rmc
-            INNER JOIN {outgoing_buffer} AS buffer ON rmc.store_model_id = buffer.model_uuid
-            WHERE buffer.transfer_session_id = '{transfer_session_id}'
-        """.format(
-        transfer_session_id=transfersession.id,
-        transfer_session_id_type=TransferSession._meta.pk.rel_db_type(connection),
-        record_max_counter=RecordMaxCounter._meta.db_table,
-        outgoing_buffer=Buffer._meta.db_table,
-    )
-
-    with connection.cursor() as cursor:
-        cursor.execute(
-            """INSERT INTO {outgoing_buffer}
-               (model_uuid, serialized, deleted, last_saved_instance, last_saved_counter,
-               hard_deleted, model_name, profile, partition, source_id, conflicting_serialized_data,
-               transfer_session_id, _self_ref_fk)
-               {select}
-            """.format(
-                outgoing_buffer=Buffer._meta.db_table,
-                select=" UNION ".join(select_buffers),
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """INSERT INTO {outgoing_buffer}
+                   (model_uuid, serialized, deleted, last_saved_instance, last_saved_counter,
+                   hard_deleted, model_name, profile, partition, source_id, conflicting_serialized_data,
+                   transfer_session_id, _self_ref_fk)
+                   {select}
+                """.format(
+                    outgoing_buffer=Buffer._meta.db_table,
+                    select=" UNION ".join(select_buffers),
+                )
             )
-        )
-        cursor.execute(
-            """INSERT INTO {outgoing_rmcb}
-               (instance_id, counter, transfer_session_id, model_uuid)
-               {select}
-            """.format(
-                outgoing_rmcb=RecordMaxCounterBuffer._meta.db_table,
-                select=select_rmc_buffer_query,
+            cursor.execute(
+                """INSERT INTO {outgoing_rmcb}
+                   (instance_id, counter, transfer_session_id, model_uuid)
+                   {select}
+                """.format(
+                    outgoing_rmcb=RecordMaxCounterBuffer._meta.db_table,
+                    select=select_rmc_buffer_query,
+                )
             )
-        )
 
 
-@transaction.atomic()
 def _dequeue_into_store(transfer_session, fsic, v2_format=False):
     """
     Takes data from the buffers and merges into the store and record max counters.
@@ -859,31 +868,30 @@ def _dequeue_into_store(transfer_session, fsic, v2_format=False):
     are not affected by previous cases.
     """
 
-    lock_partitions(DBBackend, sync_filter=Filter(transfer_session.filter), shared=False)
+    with _begin_transaction(Filter(transfer_session.filter)):
+        with connection.cursor() as cursor:
+            DBBackend._dequeuing_delete_rmcb_records(cursor, transfer_session.id)
+            DBBackend._dequeuing_delete_buffered_records(cursor, transfer_session.id)
+            current_id = InstanceIDModel.get_current_instance_and_increment_counter()
+            DBBackend._dequeuing_merge_conflict_buffer(
+                cursor, current_id, transfer_session.id
+            )
+            DBBackend._dequeuing_merge_conflict_rmcb(cursor, transfer_session.id)
+            DBBackend._dequeuing_update_rmcs_last_saved_by(
+                cursor, current_id, transfer_session.id
+            )
+            DBBackend._dequeuing_delete_mc_rmcb(cursor, transfer_session.id)
+            DBBackend._dequeuing_delete_mc_buffer(cursor, transfer_session.id)
+            DBBackend._dequeuing_insert_remaining_buffer(cursor, transfer_session.id)
+            DBBackend._dequeuing_insert_remaining_rmcb(cursor, transfer_session.id)
+            DBBackend._dequeuing_delete_remaining_rmcb(cursor, transfer_session.id)
+            DBBackend._dequeuing_delete_remaining_buffer(cursor, transfer_session.id)
 
-    with connection.cursor() as cursor:
-        DBBackend._dequeuing_delete_rmcb_records(cursor, transfer_session.id)
-        DBBackend._dequeuing_delete_buffered_records(cursor, transfer_session.id)
-        current_id = InstanceIDModel.get_current_instance_and_increment_counter()
-        DBBackend._dequeuing_merge_conflict_buffer(
-            cursor, current_id, transfer_session.id
+        DatabaseMaxCounter.update_fsics(
+            json.loads(fsic),
+            transfer_session.get_filter(),
+            v2_format=v2_format,
         )
-        DBBackend._dequeuing_merge_conflict_rmcb(cursor, transfer_session.id)
-        DBBackend._dequeuing_update_rmcs_last_saved_by(
-            cursor, current_id, transfer_session.id
-        )
-        DBBackend._dequeuing_delete_mc_rmcb(cursor, transfer_session.id)
-        DBBackend._dequeuing_delete_mc_buffer(cursor, transfer_session.id)
-        DBBackend._dequeuing_insert_remaining_buffer(cursor, transfer_session.id)
-        DBBackend._dequeuing_insert_remaining_rmcb(cursor, transfer_session.id)
-        DBBackend._dequeuing_delete_remaining_rmcb(cursor, transfer_session.id)
-        DBBackend._dequeuing_delete_remaining_buffer(cursor, transfer_session.id)
-
-    DatabaseMaxCounter.update_fsics(
-        json.loads(fsic),
-        transfer_session.get_filter(),
-        v2_format=v2_format,
-    )
 
 
 class BaseOperation(object):

--- a/morango/sync/utils.py
+++ b/morango/sync/utils.py
@@ -230,3 +230,21 @@ class SyncSignalGroup(SyncSignal):
         Fires the `completed` signal.
         """
         self.completed.fire()
+
+
+def lock_partitions(backend, sync_filter=None, shared=False):
+    """
+    Lock all partitions for a filter, and really lock everything if the filter is null
+
+    :type backend: morango.sync.backends.base.BaseSQLWrapper
+    :type sync_filter: morango.models.certificates.Filter|None
+    :type shared: bool
+    """
+    if sync_filter is None:
+        backend._lock_all_partitions(shared=shared)
+    else:
+        # parse the unique partitions in the filter
+        partitions = set(f.split(":")[0] for f in sync_filter)
+        # for every unique partition, acquire a lock
+        for partition in partitions:
+            backend._lock_partition(partition)

--- a/morango/sync/utils.py
+++ b/morango/sync/utils.py
@@ -247,4 +247,4 @@ def lock_partitions(backend, sync_filter=None, shared=False):
         partitions = set(f.split(":")[0] for f in sync_filter)
         # for every unique partition, acquire a lock
         for partition in partitions:
-            backend._lock_partition(partition)
+            backend._lock_partition(partition, shared=shared)

--- a/morango/sync/utils.py
+++ b/morango/sync/utils.py
@@ -243,8 +243,8 @@ def lock_partitions(backend, sync_filter=None, shared=False):
     if sync_filter is None:
         backend._lock_all_partitions(shared=shared)
     else:
-        # parse the unique partitions in the filter
-        partitions = set(f.split(":")[0] for f in sync_filter)
+        # parse the first 32 chars to obtain the primary partitions in the filter
+        partitions = set(f[:32] for f in sync_filter)
         # for every unique partition, acquire a lock
         for partition in partitions:
             backend._lock_partition(partition, shared=shared)

--- a/tests/testapp/testapp/postgres_settings.py
+++ b/tests/testapp/testapp/postgres_settings.py
@@ -5,13 +5,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-try:
-    isolation_level = None
-    import psycopg2
-    isolation_level = psycopg2.extensions.ISOLATION_LEVEL_SERIALIZABLE
-except ImportError:
-    pass
-
 from .settings import *  # noqa
 
 DATABASES = {
@@ -25,19 +18,6 @@ DATABASES = {
             'NAME': 'test'
         }
     },
-    'default-serializable': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'HOST': 'localhost',
-        'USER': 'postgres',
-        'PASSWORD': 'postgres',
-        'NAME': 'default',  # This module should never be used outside of tests -- so this name is irrelevant
-        'TEST': {
-            'NAME': 'test'
-        },
-        'OPTIONS': {
-            'isolation_level': isolation_level,
-        }
-    }
 }
 
 MORANGO_TEST_POSTGRESQL = True


### PR DESCRIPTION
## Summary
Prior to these changes, when Morango detected the database backend was postgres, the de/queuing and de/serialization operations opened a transaction on a separate DB connection with serializable transaction isolation. While it opened a transaction on this connection, most if not all of the code that generated queries did not use this same connection. As a result, it seems there's a very real possibility of data corruption since changes to the database aren't encapsulated within a DB transaction-- they aren't atomic. Although, I suspect that the prior implementation did still handle concurrent writes because the transaction acts like a lock within the database while the operations take place. Recent changes that added temporary tables made this issue abundantly clear on KDP because the temporary table was immediately dropped since it wasn't executed within a DB transaction. None of this was apparent in the tests because the tests usually run within a transaction anyways.

Instead of a connection with serializable transaction isolation, the work here implements advisory locking to lock affected partitions during these operations. We implemented advisory locking on Kolibri Studio to lock the channel tree during MPTT updates. This has several benefits since we'll have more control over how concurrency is actually handled. For instance, queuing buffers now open a shared lock, while all other operations open exclusive locks, allowing for more concurrency during pull syncs. And since the locking will be based off affected partitions, we'll have more capacity for concurrent syncs since syncs for separate partitions won't block each other as they would with serializable transaction isolation.

## TODO

- [ ] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

List the issues solved or partly solved by the PR

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)
