### PR TITLE
Limit transaction isolation to de/serialization and retry for serializable isolation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 List of the most important changes for each release.
 
+## 0.6.13
+- Capture and retry transaction isolation errors that occur when conflicting concurrent updates are made during the transaction
+
 ## 0.6.12
 - Replace serializable transaction isolation using a separate DB connection for Postgres with advisory locking.
 

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.12"
+__version__ = "0.6.13"

--- a/morango/sync/backends/base.py
+++ b/morango/sync/backends/base.py
@@ -10,6 +10,14 @@ class BaseSQLWrapper(object):
     def __init__(self, connection):
         self.connection = connection
 
+    def _is_transaction_isolation_error(self, error):
+        """
+        Determine if an error is related to transaction isolation
+        :param error: An exception
+        :return: A bool whether the error is a transaction isolation error
+        """
+        return False
+
     def _set_transaction_repeatable_read(self):
         """Set the current transaction isolation level"""
         pass

--- a/morango/sync/backends/postgres.py
+++ b/morango/sync/backends/postgres.py
@@ -37,6 +37,20 @@ class SQLWrapper(BaseSQLWrapper):
                 return True
         return False
 
+    def _is_transaction_isolation_error(self, error):
+        """
+        Determine if an error is related to transaction isolation
+        :param error: An exception
+        :return: A bool whether the error is a transaction isolation error
+        """
+        from psycopg2.extensions import TransactionRollbackError
+
+        # Django can wrap errors, adding it to the `__cause__` attribute
+        for e in (error, getattr(error, '__cause__', None)):
+            if isinstance(e, TransactionRollbackError) and "concurrent update" in str(e):
+                return True
+        return False
+
     def _set_transaction_repeatable_read(self):
         """Set the current transaction isolation level"""
         from psycopg2.extensions import ISOLATION_LEVEL_REPEATABLE_READ

--- a/morango/sync/backends/postgres.py
+++ b/morango/sync/backends/postgres.py
@@ -45,7 +45,7 @@ class SQLWrapper(BaseSQLWrapper):
         """
         # Django can wrap errors, adding it to the `__cause__` attribute
         for e in (error, getattr(error, '__cause__', None)):
-            if "could not serialize access due to concurrent update" in str(e):
+            if "could not serialize access due to concurrent" in str(e):
                 return True
         return False
 

--- a/morango/sync/backends/postgres.py
+++ b/morango/sync/backends/postgres.py
@@ -43,11 +43,9 @@ class SQLWrapper(BaseSQLWrapper):
         :param error: An exception
         :return: A bool whether the error is a transaction isolation error
         """
-        from psycopg2.extensions import TransactionRollbackError
-
         # Django can wrap errors, adding it to the `__cause__` attribute
         for e in (error, getattr(error, '__cause__', None)):
-            if isinstance(e, TransactionRollbackError) and "concurrent update" in str(e):
+            if "could not serialize access due to concurrent update" in str(e):
                 return True
         return False
 

--- a/morango/sync/backends/postgres.py
+++ b/morango/sync/backends/postgres.py
@@ -43,9 +43,11 @@ class SQLWrapper(BaseSQLWrapper):
         :param error: An exception
         :return: A bool whether the error is a transaction isolation error
         """
+        from psycopg2.extensions import TransactionRollbackError
+
         # Django can wrap errors, adding it to the `__cause__` attribute
         for e in (error, getattr(error, '__cause__', None)):
-            if "could not serialize access due to concurrent" in str(e):
+            if isinstance(e, TransactionRollbackError):
                 return True
         return False
 

--- a/tests/testapp/tests/sync/test_operations.py
+++ b/tests/testapp/tests/sync/test_operations.py
@@ -87,6 +87,10 @@ def _concurrent_store_write(thread_event, store_id):
 class TransactionIsolationTestCase(TransactionTestCase):
     serialized_rollback = True
 
+    def _fixture_setup(self):
+        """Don't setup fixtures for this test case"""
+        pass
+
     @override_settings(MORANGO_TEST_POSTGRESQL=False)
     def test_begin_transaction(self):
         """
@@ -97,7 +101,7 @@ class TransactionIsolationTestCase(TransactionTestCase):
         # because tests usually run within their own transaction. By the time the isolation level
         # is attempted to be set within a test, there have been reads and writes and the isolation
         # cannot be changed
-        with _begin_transaction(None):
+        with _begin_transaction(None, isolated=True):
             create_dummy_store_data()
 
     @pytest.mark.skipif(

--- a/tests/testapp/tests/sync/test_operations.py
+++ b/tests/testapp/tests/sync/test_operations.py
@@ -1,12 +1,16 @@
 import json
+import threading
 import uuid
+from time import sleep
 
 import factory
 import mock
 import pytest
+from django.conf import settings
 from django.db import connection
 from django.test import override_settings
 from django.test import TestCase
+from django.test import TransactionTestCase
 from django.utils import timezone
 from facility_profile.models import Facility
 from facility_profile.models import MyUser
@@ -17,6 +21,7 @@ from ..helpers import create_dummy_store_data
 from morango.constants import transfer_statuses
 from morango.constants.capabilities import FSIC_V2_FORMAT
 from morango.errors import MorangoLimitExceeded
+from morango.models.certificates import Filter
 from morango.models.core import Buffer
 from morango.models.core import DatabaseIDModel
 from morango.models.core import DatabaseMaxCounter
@@ -72,19 +77,62 @@ def assertRecordsNotBuffered(records):
         assert i.id not in rmcb_ids
 
 
-@pytest.mark.django_db(transaction=False)
-def test_begin_transaction():
-    """
-    Assert that we can start a transaction using our util and make some writes without
-    raising errors, specifically
-    """
-    # the utility we're testing here avoids setting the isolation level when this setting is True
-    # because tests usually run within their own transaction. By the time the isolation level
-    # is attempted to be set within a test, there have been reads and writes and the isolation
-    # cannot be changed
-    with override_settings(MORANGO_TEST_POSTGRESQL=False):
+def _concurrent_store_write(thread_event, store_id):
+    while not thread_event.is_set():
+        sleep(.1)
+    Store.objects.filter(id=store_id).delete()
+    connection.close()
+
+
+class TransactionIsolationTestCase(TransactionTestCase):
+    serialized_rollback = True
+
+    @override_settings(MORANGO_TEST_POSTGRESQL=False)
+    def test_begin_transaction(self):
+        """
+        Assert that we can start a transaction using our util and make some writes without
+        raising errors, specifically
+        """
+        # the utility we're testing here avoids setting the isolation level when this setting is True
+        # because tests usually run within their own transaction. By the time the isolation level
+        # is attempted to be set within a test, there have been reads and writes and the isolation
+        # cannot be changed
         with _begin_transaction(None):
             create_dummy_store_data()
+
+    @pytest.mark.skipif(
+        not getattr(settings, "MORANGO_TEST_POSTGRESQL", False), reason="Not supported"
+    )
+    def test_transaction_isolation_handling(self):
+        store = Store.objects.create(
+            id=uuid.uuid4().hex,
+            last_saved_instance=uuid.uuid4().hex,
+            last_saved_counter=1,
+            partition=uuid.uuid4().hex,
+            profile="facilitydata",
+            source_id="qqq",
+            model_name="qqq",
+        )
+
+        concurrent_event = threading.Event()
+        concurrent_thread = threading.Thread(
+            target=_concurrent_store_write,
+            args=(concurrent_event, store.id),
+        )
+        concurrent_thread.start()
+
+        try:
+            with _begin_transaction(Filter(store.partition), isolated=True):
+                s = Store.objects.get(id=store.id)
+                concurrent_event.set()
+                sleep(.2)
+                s.last_saved_counter += 1
+                s.save()
+            raise AssertionError("Didn't raise transactional error")
+        except Exception as e:
+            self.assertTrue(DBBackend._is_transaction_isolation_error(e))
+        finally:
+            concurrent_thread.join(5)
 
 
 @override_settings(MORANGO_SERIALIZE_BEFORE_QUEUING=False, MORANGO_DISABLE_FSIC_V2_FORMAT=True)


### PR DESCRIPTION
## Summary

The _repeatable-read_ transaction isolation can raise errors when there have been concurrent updates to records modified during the transaction. This update catches them at the transfer stage operations level to return a `PENDING` status which signals that the operation should be retried, either for a status update (like for async operations) or to actually retry them (like in this case)

```
ERROR:  could not serialize access due to concurrent update
```

## TODO
- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file
