### PR TITLE
Consolidate sync client operation to use composite context

### DIFF
--- a/morango/constants/settings.py
+++ b/morango/constants/settings.py
@@ -23,7 +23,9 @@ MORANGO_QUEUE_OPERATIONS = (
 )
 MORANGO_TRANSFERRING_OPERATIONS = (
     "morango.sync.operations:PullProducerOperation",
+    "morango.sync.operations:PushProducerOperation",
     "morango.sync.operations:PushReceiverOperation",
+    "morango.sync.operations:PullReceiverOperation",
     "morango.sync.operations:NetworkPushTransferOperation",
     "morango.sync.operations:NetworkPullTransferOperation",
 )

--- a/morango/models/core.py
+++ b/morango/models/core.py
@@ -449,7 +449,7 @@ class Store(AbstractStore):
 
     class Meta:
         indexes = [
-            models.Index(fields=['partition'], name='idx_morango_store_partition'),
+            models.Index(fields=["partition"], name="idx_morango_store_partition"),
         ]
 
     def _deserialize_store_model(self, fk_cache, defer_fks=False):  # noqa: C901
@@ -777,7 +777,9 @@ class RecordMaxCounterBuffer(AbstractCounter):
     model_uuid = UUIDField(db_index=True)
 
 
-ForeignKeyReference = namedtuple("ForeignKeyReference", ["from_field", "from_pk", "to_pk"])
+ForeignKeyReference = namedtuple(
+    "ForeignKeyReference", ["from_field", "from_pk", "to_pk"]
+)
 
 
 class SyncableModel(UUIDModelMixin):
@@ -908,7 +910,7 @@ class SyncableModel(UUIDModelMixin):
                 ForeignKeyReference(
                     from_field=field.attname,
                     from_pk=self.pk,
-                    to_pk=getattr(self, field.attname)
+                    to_pk=getattr(self, field.attname),
                 )
             )
 

--- a/morango/registry.py
+++ b/morango/registry.py
@@ -2,8 +2,8 @@
 `SyncableModelRegistry` holds all syncable models for a project, on a per profile basis.
 This class is registered at app load time for morango in `apps.py`.
 """
-import sys
 import inspect
+import sys
 from collections import OrderedDict
 
 from django.db.models.fields.related import ForeignKey
@@ -196,6 +196,7 @@ class SessionMiddlewareOperations(list):
     Iterable list class that holds and initializes a list of transfer operations as configured
     through Morango settings, and associate the group with a transfer stage by `related_stage`
     """
+
     __slots__ = ("related_stage",)
 
     def __init__(self, related_stage):
@@ -230,7 +231,9 @@ class SessionMiddlewareOperations(list):
                 return result
         else:
             raise NotImplementedError(
-                "Operation for {} stage has no middleware".format(self.related_stage)
+                "Operation for {} stage has no applicable middleware for context '{}'".format(
+                    self.related_stage, context.__class__.__name__
+                )
             )
 
 

--- a/morango/sync/context.py
+++ b/morango/sync/context.py
@@ -56,7 +56,7 @@ class SessionContext(object):
             if transfer_session.filter:
                 self.filter = transfer_session.get_filter()
 
-    def prime(self):
+    def prepare(self):
         """
         Perform any processing of the session context prior to passing it to the middleware,
         and return the context as it should be passed to the middleware
@@ -366,7 +366,7 @@ class CompositeSessionContext(SessionContext):
         The maximum amount of time to wait between retries
         :return: A number of seconds
         """
-        return self.prime().max_backoff_interval
+        return self.prepare().max_backoff_interval
 
     @property
     def stage(self):
@@ -396,9 +396,9 @@ class CompositeSessionContext(SessionContext):
                 set_attr = "filter" if attr == "sync_filter" else attr
                 setattr(context, set_attr, value)
 
-    def prime(self):
+    def prepare(self):
         """
-        Priming this context will return the current sub context that needs completion
+        Preparing this context will return the current sub context that needs completion
         """
         return self.children[self._counter % len(self.children)]
 
@@ -463,7 +463,7 @@ class CompositeSessionContext(SessionContext):
             self._stage = stage
 
         # when finishing a stage without an error, we'll increment the counter by one such that
-        # `prime` returns the next context to process
+        # `prepare` returns the next context to process
         if stage_status == transfer_statuses.COMPLETED:
             self._counter += 1
 

--- a/morango/sync/context.py
+++ b/morango/sync/context.py
@@ -491,8 +491,6 @@ class CompositeSessionContext(SessionContext):
         """Re-apply dict state after serialization"""
         self.children = state.get("children", [])
         self._counter = state.get("counter", 0)
-
-        stage = state.get("stage", None)
-        stage_status = state.get("stage_status", None)
-        self.update_state(stage=stage, stage_status=stage_status)
+        self._stage = state.get("stage", None)
+        self._stage_status = state.get("stage_status", None)
         self.error = state.get("error", None)

--- a/morango/sync/context.py
+++ b/morango/sync/context.py
@@ -4,8 +4,8 @@ from morango.errors import MorangoContextUpdateError
 from morango.models.certificates import Filter
 from morango.models.core import SyncSession
 from morango.models.core import TransferSession
-from morango.utils import parse_capabilities_from_server_request
 from morango.utils import CAPABILITIES
+from morango.utils import parse_capabilities_from_server_request
 
 
 class SessionContext(object):
@@ -21,6 +21,7 @@ class SessionContext(object):
         "capabilities",
         "error",
     )
+    max_backoff_interval = 5
 
     def __init__(
         self,
@@ -54,6 +55,13 @@ class SessionContext(object):
             self.is_push = transfer_session.push or self.is_push
             if transfer_session.filter:
                 self.filter = transfer_session.get_filter()
+
+    def prime(self):
+        """
+        Perform any processing of the session context prior to passing it to the middleware,
+        and return the context as it should be passed to the middleware
+        """
+        return self
 
     def update(
         self,
@@ -186,6 +194,7 @@ class LocalSessionContext(SessionContext):
         "request",
         "is_server",
     )
+    max_backoff_interval = 1
 
     def __init__(self, request=None, **kwargs):
         """
@@ -194,13 +203,21 @@ class LocalSessionContext(SessionContext):
             passed in.
         :type request: django.http.request.HttpRequest
         """
-        capabilities = kwargs.pop("capabilities", [])
-        if request is not None:
-            capabilities = parse_capabilities_from_server_request(request)
-
-        super(LocalSessionContext, self).__init__(capabilities=capabilities, **kwargs)
+        super(LocalSessionContext, self).__init__(**kwargs)
         self.request = request
         self.is_server = request is not None
+
+    @classmethod
+    def from_request(cls, request, **kwargs):
+        """
+        Parse capabilities from request and instantiate the LocalSessionContext
+        :param request: The request object
+        :type request: django.http.request.HttpRequest
+        :param kwargs: Any other keyword args for the constructor
+        :rtype: LocalSessionContext
+        """
+        kwargs.update(capabilities=parse_capabilities_from_server_request(request))
+        return LocalSessionContext(request=request, **kwargs)
 
     @property
     def _has_transfer_session(self):
@@ -288,9 +305,7 @@ class NetworkSessionContext(SessionContext):
         :type connection: NetworkSyncConnection
         """
         self.connection = connection
-        super(NetworkSessionContext, self).__init__(
-            capabilities=self.connection.server_info.get("capabilities", []), **kwargs
-        )
+        super(NetworkSessionContext, self).__init__(**kwargs)
 
         # since this is network context, keep local reference to state vars
         self._stage = transfer_stages.INITIALIZING
@@ -317,3 +332,167 @@ class NetworkSessionContext(SessionContext):
         """
         self._stage = stage or self._stage
         self._stage_status = stage_status or self._stage_status
+
+
+class CompositeSessionContext(SessionContext):
+    """
+    A composite context class that acts as a facade for more than one context, to facilitate
+    "simpler" operation on local and remote contexts simultaneously
+    """
+
+    __slots__ = (
+        "children",
+        "_counter",
+        "_stage",
+        "_stage_status",
+    )
+
+    def __init__(self, contexts, *args, **kwargs):
+        """
+        :param contexts: A list of context objects
+        :param args: Args to pass to the parent constructor
+        :param kwargs: Keyword args to pass to the parent constructor
+        """
+        self.children = contexts
+        self._counter = 0
+        self._stage = transfer_stages.INITIALIZING
+        self._stage_status = transfer_statuses.PENDING
+        super(CompositeSessionContext, self).__init__(*args, **kwargs)
+        self._update_attrs(**kwargs)
+
+    @property
+    def max_backoff_interval(self):
+        """
+        The maximum amount of time to wait between retries
+        :return: A number of seconds
+        """
+        return self.prime().max_backoff_interval
+
+    @property
+    def stage(self):
+        """
+        The stage of the transfer context
+        :return: A transfer_stages.* constant
+        :rtype: str
+        """
+        return self._stage
+
+    @property
+    def stage_status(self):
+        """
+        The status of the transfer context's stage
+        :return: A transfer_statuses.* constant
+        :rtype: str
+        """
+        return self._stage_status
+
+    def _update_attrs(self, **kwargs):
+        """
+        Updates all contexts by applying key/value arguments as attributes. This avoids using the
+        contexts' update methods because some validation is already handled in this class.
+        """
+        for context in self.children:
+            for attr, value in kwargs.items():
+                set_attr = "filter" if attr == "sync_filter" else attr
+                setattr(context, set_attr, value)
+
+    def prime(self):
+        """
+        Priming this context will return the current sub context that needs completion
+        """
+        return self.children[self._counter % len(self.children)]
+
+    def update(self, stage=None, stage_status=None, **kwargs):
+        """
+        Updates the context object and its state
+        :param stage: The str transfer stage
+        :param stage_status: The str transfer stage status
+        :param kwargs: Other arguments to update the context with
+        """
+        # update ourselves, but exclude stage and stage_status
+        super(CompositeSessionContext, self).update(**kwargs)
+        # update children contexts directly, but exclude stage and stage_status
+        self._update_attrs(**kwargs)
+        # handle state changes after updating children
+        self.update_state(stage=stage, stage_status=stage_status)
+
+        # During the initializing stage, we want to make sure to synchronize the transfer session
+        # object between the composite and children contexts, using whatever child context's
+        # transfer session object that was updated on the context during initialization
+        current_stage = stage or self._stage
+        if not self.transfer_session and current_stage == transfer_stages.INITIALIZING:
+            try:
+                transfer_session = next(
+                    c.transfer_session for c in self.children if c.transfer_session
+                )
+                # prepare an updates dictionary, so we can update everything at once
+                updates = dict(transfer_session=transfer_session)
+
+                # if the transfer session is being resumed, we'd detect a different stage here,
+                # and thus we reset the counter, so we can be sure to start fresh at that stage
+                # on the next invocation of the middleware
+                if (
+                    transfer_session.transfer_stage
+                    and transfer_session.transfer_stage != current_stage
+                ):
+                    self._counter = 0
+                    updates.update(
+                        stage=transfer_session.transfer_stage,
+                        stage_status=transfer_statuses.PENDING,
+                    )
+
+                # recurse into update with transfer session and possibly state updates too
+                self.update(**updates)
+            except StopIteration:
+                pass
+
+    def update_state(self, stage=None, stage_status=None):
+        """
+        Updates the state of the transfer
+        :type stage: transfer_stages.*|None
+        :type stage_status: transfer_statuses.*|None
+        """
+        # parent's update method can pass through None values
+        if stage is None and stage_status is None:
+            return
+
+        # advance the composite's stage when we move forward only
+        if stage is not None and transfer_stages.stage(stage) > transfer_stages.stage(
+            self._stage
+        ):
+            self._stage = stage
+
+        # when finishing a stage without an error, we'll increment the counter by one such that
+        # `prime` returns the next context to process
+        if stage_status == transfer_statuses.COMPLETED:
+            self._counter += 1
+
+        # when we've completed a loop through all contexts (modulus is zero), we want to bring
+        # all the contexts' states up to date
+        if (
+            self._counter % len(self.children) == 0
+            or stage_status == transfer_statuses.ERRORED
+        ):
+            for context in self.children:
+                context.update_state(stage=stage, stage_status=stage_status)
+            if stage_status is not None:
+                self._stage_status = stage_status
+
+    def __getstate__(self):
+        """Return dict of simplified data for serialization"""
+        return dict(
+            children=self.children,
+            counter=self._counter,
+            stage=self._stage,
+            stage_status=self._stage_status,
+        )
+
+    def __setstate__(self, state):
+        """Re-apply dict state after serialization"""
+        self.children = state.get("children", [])
+        self._counter = state.get("counter", 0)
+
+        stage = state.get("stage", None)
+        stage_status = state.get("stage_status", None)
+        self.update_state(stage=stage, stage_status=stage_status)
+        self.error = state.get("error", None)

--- a/morango/sync/controller.py
+++ b/morango/sync/controller.py
@@ -186,7 +186,9 @@ class SessionController(object):
         # should always be a non-False status
         return result
 
-    def proceed_to_and_wait_for(self, target_stage, context=None, max_interval=5):
+    def proceed_to_and_wait_for(
+        self, target_stage, context=None, max_interval=None, callback=None
+    ):
         """
         Same as `proceed_to` but waits for a finished status to be returned by sleeping between
         calls to `proceed_to` if status is not complete
@@ -196,18 +198,24 @@ class SessionController(object):
         :param context: Override controller context, or provide it if missing
         :type context: morango.sync.context.SessionContext|None
         :param max_interval: The max time, in seconds, between repeat calls to `.proceed_to`
+        :param callback: A callable to invoke on every retry
         :return: transfer_status.* - The status of proceeding to that stage,
             which should be `ERRORED` or `COMPLETE`
         :rtype: str
         """
         result = transfer_statuses.PENDING
         tries = 0
+        context = context or self.context
+        max_interval = max_interval or context.max_backoff_interval
+
         while result not in transfer_statuses.FINISHED_STATES:
             if tries > 0:
                 # exponential backoff up to max_interval
                 sleep(min(0.3 * (2 ** tries - 1), max_interval))
             result = self.proceed_to(target_stage, context=context)
             tries += 1
+            if callable(callback):
+                callback()
         return result
 
     def _invoke_middleware(self, context, middleware):
@@ -223,16 +231,21 @@ class SessionController(object):
         stage = middleware.related_stage
         signal = getattr(self.signals, stage)
         at_stage = context.stage == stage
+        primed_context = None
 
         try:
             context.update(stage=stage, stage_status=transfer_statuses.PENDING)
 
+            # we'll use the primed context for passing to the middleware and any signal handlers
+            primed_context = context.prime()
+
             # only fire "started" when we first try to invoke the stage
             # NOTE: this means that signals.started is not equivalent to transfer_stage.STARTED
             if not at_stage:
-                signal.started.fire(context=context)
+                signal.started.fire(context=primed_context)
 
-            result = middleware(context)
+            # invoke the middleware with the primed context
+            result = middleware(primed_context)
 
             # don't update stage result if context's stage was updated during operation
             if context.stage == stage:
@@ -240,15 +253,16 @@ class SessionController(object):
 
             # fire signals based off middleware invocation result; the progress signal if incomplete
             if result == transfer_statuses.COMPLETED:
-                signal.completed.fire(context=context)
+                signal.completed.fire(context=primed_context)
             else:
-                signal.in_progress.fire(context=context)
+                signal.in_progress.fire(context=primed_context)
 
-            return result
+            # context should take precedence over result, and was likely updated
+            return context.stage_status
         except Exception as e:
             # always log the error itself
             logger.error(e)
             context.update(stage_status=transfer_statuses.ERRORED, error=e)
             # fire completed signal, after context update. handlers can use context to detect error
-            signal.completed.fire(context=context)
+            signal.completed.fire(context=primed_context or context)
             return transfer_statuses.ERRORED

--- a/morango/sync/controller.py
+++ b/morango/sync/controller.py
@@ -198,7 +198,7 @@ class SessionController(object):
         :param context: Override controller context, or provide it if missing
         :type context: morango.sync.context.SessionContext|None
         :param max_interval: The max time, in seconds, between repeat calls to `.proceed_to`
-        :param callback: A callable to invoke on every retry
+        :param callback: A callable to invoke after every attempt
         :return: transfer_status.* - The status of proceeding to that stage,
             which should be `ERRORED` or `COMPLETE`
         :rtype: str
@@ -231,21 +231,21 @@ class SessionController(object):
         stage = middleware.related_stage
         signal = getattr(self.signals, stage)
         at_stage = context.stage == stage
-        primed_context = None
+        prepared_context = None
 
         try:
             context.update(stage=stage, stage_status=transfer_statuses.PENDING)
 
-            # we'll use the primed context for passing to the middleware and any signal handlers
-            primed_context = context.prime()
+            # we'll use the prepared context for passing to the middleware and any signal handlers
+            prepared_context = context.prepare()
 
             # only fire "started" when we first try to invoke the stage
             # NOTE: this means that signals.started is not equivalent to transfer_stage.STARTED
             if not at_stage:
-                signal.started.fire(context=primed_context)
+                signal.started.fire(context=prepared_context)
 
-            # invoke the middleware with the primed context
-            result = middleware(primed_context)
+            # invoke the middleware with the prepared context
+            result = middleware(prepared_context)
 
             # don't update stage result if context's stage was updated during operation
             if context.stage == stage:
@@ -253,9 +253,9 @@ class SessionController(object):
 
             # fire signals based off middleware invocation result; the progress signal if incomplete
             if result == transfer_statuses.COMPLETED:
-                signal.completed.fire(context=primed_context)
+                signal.completed.fire(context=prepared_context)
             else:
-                signal.in_progress.fire(context=primed_context)
+                signal.in_progress.fire(context=prepared_context)
 
             # context should take precedence over result, and was likely updated
             return context.stage_status
@@ -264,5 +264,5 @@ class SessionController(object):
             logger.error(e)
             context.update(stage_status=transfer_statuses.ERRORED, error=e)
             # fire completed signal, after context update. handlers can use context to detect error
-            signal.completed.fire(context=primed_context or context)
+            signal.completed.fire(context=prepared_context or context)
             return transfer_statuses.ERRORED

--- a/tests/testapp/tests/helpers.py
+++ b/tests/testapp/tests/helpers.py
@@ -92,7 +92,7 @@ def create_dummy_store_data():
         profile="facilitydata",
         last_activity_timestamp=timezone.now(),
     )
-    data["sc"].current_transfer_session = TransferSession.objects.create(
+    data["tx"] = TransferSession.objects.create(
         id=uuid.uuid4().hex,
         sync_session=session,
         push=True,
@@ -418,13 +418,10 @@ class BaseTransferClientTestCase(BaseClientTestCase):
             )
 
         client = super(BaseTransferClientTestCase, self).build_client(client_class=client_class, controller=controller)
-        client.current_transfer_session = self.transfer_session
-        if client.local_context.is_push is None:
-            client.local_context.update(is_push=self.transfer_session.push)
-            client.remote_context.update(is_push=self.transfer_session.push)
+        if client.context.is_push is None:
+            client.context.update(is_push=self.transfer_session.push)
         if update_context:
-            client.local_context.update(transfer_session=self.transfer_session)
-            client.remote_context.update(transfer_session=self.transfer_session)
+            client.context.update(transfer_session=self.transfer_session)
         return client
 
 

--- a/tests/testapp/tests/sync/test_context.py
+++ b/tests/testapp/tests/sync/test_context.py
@@ -298,8 +298,8 @@ class CompositeSessionContextTestCase(SimpleTestCase):
             self.sub_context_a.update_state.reset_mock()
             self.sub_context_b.update_state.reset_mock()
 
-            primed_context = self.context.prime()
-            self.assertIs(primed_context, self.sub_context_a)
+            prepared_context = self.context.prepare()
+            self.assertIs(prepared_context, self.sub_context_a)
 
             # pretend the initialization stage ran successfully
             if stage == transfer_stages.INITIALIZING:
@@ -317,8 +317,8 @@ class CompositeSessionContextTestCase(SimpleTestCase):
             self.sub_context_a.update_state.assert_not_called()
             self.sub_context_b.update_state.assert_not_called()
 
-            primed_context = self.context.prime()
-            self.assertIs(primed_context, self.sub_context_b)
+            prepared_context = self.context.prepare()
+            self.assertIs(prepared_context, self.sub_context_b)
 
             self.context.update(stage_status=transfer_statuses.COMPLETED)
             self.sub_context_a.update_state.assert_called_once_with(stage=None, stage_status=transfer_statuses.COMPLETED)


### PR DESCRIPTION
## Summary
- Adds new `CompositeSessionContext` class that can manage multiple contexts at once, specifically for managing a local and remote context simultaneously, ensuring the state of each is transfer session, local and remote, is kept in sync as much as possible
- Refactors the sync client class to use a new context class that wraps the local and remote contexts
- Other minor refactoring to accommodate existing behavior

## TODO

- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Issues addressed

https://github.com/learningequality/morango/issues/157
