### PR TITLE
Refactor transaction isolation handling and some cleanup

### DIFF
--- a/morango/errors.py
+++ b/morango/errors.py
@@ -76,3 +76,7 @@ class MorangoInvalidFSICPartition(MorangoError):
 
 class MorangoSkipOperation(MorangoError):
     pass
+
+
+class MorangoDatabaseError(MorangoError):
+    pass

--- a/morango/models/core.py
+++ b/morango/models/core.py
@@ -122,7 +122,7 @@ class InstanceIDModel(models.Model):
     hostname = models.TextField()
     sysversion = models.TextField()
     node_id = models.CharField(max_length=20, blank=True)
-    database = models.ForeignKey(DatabaseIDModel)
+    database = models.ForeignKey(DatabaseIDModel, on_delete=models.CASCADE)
     counter = models.IntegerField(default=0)
     current = models.BooleanField(default=True)
     db_path = models.CharField(max_length=1000)
@@ -219,10 +219,10 @@ class SyncSession(models.Model):
 
     # track the certificates being used by each side for this session
     client_certificate = models.ForeignKey(
-        Certificate, blank=True, null=True, related_name="syncsessions_client"
+        Certificate, blank=True, null=True, related_name="syncsessions_client", on_delete=models.CASCADE
     )
     server_certificate = models.ForeignKey(
-        Certificate, blank=True, null=True, related_name="syncsessions_server"
+        Certificate, blank=True, null=True, related_name="syncsessions_server", on_delete=models.CASCADE
     )
 
     # track the morango profile this sync session is happening for
@@ -280,7 +280,7 @@ class TransferSession(models.Model):
     bytes_sent = models.BigIntegerField(default=0, null=True, blank=True)
     bytes_received = models.BigIntegerField(default=0, null=True, blank=True)
 
-    sync_session = models.ForeignKey(SyncSession)
+    sync_session = models.ForeignKey(SyncSession, on_delete=models.CASCADE)
 
     # track when the transfer session started and the last time there was activity on it
     start_timestamp = models.DateTimeField(default=timezone.now)
@@ -527,7 +527,7 @@ class Buffer(AbstractStore):
     dequeuing into the local store.
     """
 
-    transfer_session = models.ForeignKey(TransferSession)
+    transfer_session = models.ForeignKey(TransferSession, on_delete=models.CASCADE)
     model_uuid = UUIDField()
 
     class Meta:
@@ -761,7 +761,7 @@ class RecordMaxCounter(AbstractCounter):
     during the sync process.
     """
 
-    store_model = models.ForeignKey(Store)
+    store_model = models.ForeignKey(Store, on_delete=models.CASCADE)
 
     class Meta:
         unique_together = ("store_model", "instance_id")
@@ -773,7 +773,7 @@ class RecordMaxCounterBuffer(AbstractCounter):
     until they are sent or received by another morango instance.
     """
 
-    transfer_session = models.ForeignKey(TransferSession)
+    transfer_session = models.ForeignKey(TransferSession, on_delete=models.CASCADE)
     model_uuid = UUIDField(db_index=True)
 
 

--- a/morango/sync/backends/base.py
+++ b/morango/sync/backends/base.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 from morango.models.core import Buffer
 from morango.models.core import RecordMaxCounter
 from morango.models.core import RecordMaxCounterBuffer
@@ -18,9 +20,10 @@ class BaseSQLWrapper(object):
         """
         return False
 
+    @contextmanager
     def _set_transaction_repeatable_read(self):
         """Set the current transaction isolation level"""
-        pass
+        yield
 
     def _create_placeholder_list(self, fields, db_values):
         # number of rows to update

--- a/morango/sync/controller.py
+++ b/morango/sync/controller.py
@@ -129,10 +129,10 @@ class SessionController(object):
         When invoking the middleware, if the status result is:
             PENDING: The controller will continue to invoke the middleware again when this method
                 is called repeatedly, until the status result changes
-            STARTED: The controller will not invoke any middleware until the the status changes,
+            STARTED: The controller will not invoke any middleware until the status changes,
                 and assumes the "started" operation will update the state itself
             COMPLETED: The controller will proceed to invoke the middleware for the next stage
-            ERRORED: The controller will not invoke any middleware until the the status changes,
+            ERRORED: The controller will not invoke any middleware until the status changes,
                 which would require codified resolution of the error outside of the controller
 
         :param target_stage: transfer_stage.* - The transfer stage to proceed to

--- a/tests/testapp/tests/sync/test_operations.py
+++ b/tests/testapp/tests/sync/test_operations.py
@@ -91,9 +91,6 @@ class TransactionIsolationTestCase(TransactionTestCase):
         """Don't setup fixtures for this test case"""
         pass
 
-    def _fixture_teardown(self):
-        pass
-
     @override_settings(MORANGO_TEST_POSTGRESQL=False)
     def test_begin_transaction(self):
         """
@@ -118,6 +115,12 @@ class TransactionIsolationTestCase(TransactionTestCase):
                 last_activity_timestamp=timezone.now(),
             )
             create_buffer_and_store_dummy_data(transfer_session.id)
+
+        # manual cleanup
+        self.assertNotEqual(0, Store.objects.all().count())
+        # will cascade delete
+        SyncSession.objects.all().delete()
+        Store.objects.all().delete()
 
     @pytest.mark.skipif(
         not getattr(settings, "MORANGO_TEST_POSTGRESQL", False), reason="Not supported"


### PR DESCRIPTION
## Summary
- Adds explicit `on_delete=models.CASCADE` to all models since its implicit definition is deprecated in Django 2+
- Refactors modification of the transaction isolation level to be more robust, and to revert back to previous settings after
- Enhances tests for the above refactor

## TODO

- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file


## Issues addressed
Fixes https://github.com/learningequality/morango/issues/170


