### PR TITLE
Remove deprecation warnings for field attributes and on_cascade.

### DIFF
--- a/morango/models/certificates.py
+++ b/morango/models/certificates.py
@@ -35,13 +35,13 @@ class Certificate(mptt.models.MPTTModel, UUIDModelMixin):
 
     uuid_input_fields = ("public_key", "profile", "salt")
 
-    parent = models.ForeignKey("Certificate", blank=True, null=True)
+    parent = models.ForeignKey("Certificate", blank=True, null=True, on_delete=models.CASCADE)
 
     # the Morango profile with which this certificate is associated
     profile = models.CharField(max_length=20)
 
     # scope of this certificate, and version of the scope, along with associated params
-    scope_definition = models.ForeignKey("ScopeDefinition")
+    scope_definition = models.ForeignKey("ScopeDefinition", on_delete=models.CASCADE)
     scope_version = models.IntegerField()
     scope_params = (
         models.TextField()

--- a/morango/registry.py
+++ b/morango/registry.py
@@ -19,7 +19,7 @@ from morango.utils import SETTINGS
 
 def _get_foreign_key_classes(m):
     return set(
-        [field.rel.to for field in m._meta.fields if isinstance(field, ForeignKey)]
+        [field.related_model for field in m._meta.fields if isinstance(field, ForeignKey)]
     )
 
 

--- a/tests/testapp/facility_profile/models.py
+++ b/tests/testapp/facility_profile/models.py
@@ -32,7 +32,7 @@ class Facility(MorangoMPTTModel, FacilityDataSyncableModel):
 
     name = models.CharField(max_length=100)
     now_date = models.DateTimeField(default=timezone.now)
-    parent = TreeForeignKey('self', null=True, blank=True, related_name='children', db_index=True)
+    parent = TreeForeignKey('self', null=True, blank=True, related_name='children', db_index=True, on_delete=models.CASCADE)
 
     def calculate_source_id(self, *args, **kwargs):
         return self.name
@@ -42,7 +42,7 @@ class Facility(MorangoMPTTModel, FacilityDataSyncableModel):
 
     def clean_fields(self, *args, **kwargs):
         # reference parent here just to trigger a non-validation error to make sure we handle it
-        parent = self.parent
+        _ = self.parent
         super(Facility, self).clean_fields(*args, **kwargs)
 
 
@@ -69,7 +69,7 @@ class MyUser(AbstractBaseUser, FacilityDataSyncableModel):
         return '{id}:user'.format(id=self.ID_PLACEHOLDER)
 
     def has_morango_certificate_scope_permission(self, scope_definition_id, scope_params):
-        return self.is_superuser        
+        return self.is_superuser
 
     @staticmethod
     def compute_namespaced_id(partition_value, source_id_value, model_name):
@@ -80,7 +80,7 @@ class SummaryLog(FacilityDataSyncableModel):
     # Morango syncing settings
     morango_model_name = "contentsummarylog"
 
-    user = models.ForeignKey(MyUser)
+    user = models.ForeignKey(MyUser, on_delete=models.CASCADE)
     content_id = UUIDField(db_index=True, default=uuid.uuid4)
 
     def calculate_source_id(self, *args, **kwargs):
@@ -94,7 +94,7 @@ class InteractionLog(FacilityDataSyncableModel):
     # Morango syncing settings
     morango_model_name = "contentinteractionlog"
 
-    user = models.ForeignKey(MyUser, blank=True, null=True)
+    user = models.ForeignKey(MyUser, blank=True, null=True, on_delete=models.CASCADE)
     content_id = UUIDField(db_index=True, default=uuid.uuid4)
 
     def calculate_source_id(self, *args, **kwargs):


### PR DESCRIPTION
## Summary
* Removes reference to deprecated `rel.to` on Foreign Key fields
* Adds `on_cascade` property to all ForeignKey fields.

Existing tests should provide coverage of these changes.
