### PR TITLE
Add regression test and fix for overflow waiting error

### DIFF
--- a/morango/sync/controller.py
+++ b/morango/sync/controller.py
@@ -209,7 +209,7 @@ class SessionController(object):
         context = context or self.context
         max_interval = max_interval or context.max_backoff_interval
         # solve for the number of tries at which our sleep time will always be max_interval
-        max_interval_tries = round(1 + ((math.log(max_interval) - math.log(0.3)) / math.log(2)))
+        max_interval_tries = math.ceil(math.log(max_interval / 0.3 + 1) / math.log(2))
 
         while result not in transfer_statuses.FINISHED_STATES:
             if tries > 0:

--- a/morango/sync/controller.py
+++ b/morango/sync/controller.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from time import sleep
 
 from morango.constants import transfer_stages
@@ -207,11 +208,16 @@ class SessionController(object):
         tries = 0
         context = context or self.context
         max_interval = max_interval or context.max_backoff_interval
+        # solve for the number of tries at which our sleep time will always be max_interval
+        max_interval_tries = round(1 + ((math.log(max_interval) - math.log(0.3)) / math.log(2)))
 
         while result not in transfer_statuses.FINISHED_STATES:
             if tries > 0:
                 # exponential backoff up to max_interval
-                sleep(min(0.3 * (2 ** tries - 1), max_interval))
+                if tries >= max_interval_tries:
+                    sleep(max_interval)
+                else:
+                    sleep(0.3 * (2 ** tries - 1))
             result = self.proceed_to(target_stage, context=context)
             tries += 1
             if callable(callback):


### PR DESCRIPTION
## Summary
- @AllanOXDi and I co-hacked on this fix
- We solved for that maximum tries that would cause the sleep time to always be `max_interval` to avoid causing overflow errors when multiplying a float with a large number

## TODO

- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance
- Run the tests-- do they pass?
- Check my math-- did I determine `max_interval_tries` correctly?

## Issues addressed

Fixes https://github.com/learningequality/morango/issues/173
