### PR TITLE
Remove hardcoded bash path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := bash
 
 .ONESHELL:
 .PHONY: help clean clean-pyc release dist


### PR DESCRIPTION
## Summary

Hardcoding the `bash` path creates issues on systems that have bash stored in a different location, such as NixOS.
