### PR TITLE
Adds cleanupsyncs command parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release Notes
 
 List of the most important changes for each release.
+## 0.16.17
+- Added `client-instance-id`, `server-instance-id`, `sync-filter`, `push` and `pull` arguments to `cleanupsyncs` management command
 
 ## 0.6.16
 - Added dedicated `client_instance_id` and `server_instance_id` fields to `SyncSession`

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.16"
+__version__ = "0.6.17"

--- a/morango/management/commands/cleanupsyncs.py
+++ b/morango/management/commands/cleanupsyncs.py
@@ -31,19 +31,19 @@ class Command(BaseCommand):
             help="Number of hours of inactivity after which a session should be considered stale",
         )
         parser.add_argument(
-            "--client_instance_id",
+            "--client-instance-id",
             type=uuid.UUID,
             default=None,
             help="Filters the SyncSession models to those with matching 'client_instance_id'",
         )
         parser.add_argument(
-            "--server_instance_id",
+            "--server-instance-id",
             type=uuid.UUID,
             default=None,
             help="Filters the SyncSession models to those with matching 'server_instance_id'",
         )
         parser.add_argument(
-            "--sync_filter",
+            "--sync-filter",
             type=str,
             default=None,
             help="Filters the TransferSession models to those with 'filters' starting with 'sync_filter'",

--- a/tests/testapp/tests/test_management_commands.py
+++ b/tests/testapp/tests/test_management_commands.py
@@ -10,7 +10,7 @@ from morango.models.core import SyncSession
 from morango.models.core import TransferSession
 
 
-def _create_sessions(last_activity_offset=0, sync_session=None):
+def _create_sessions(last_activity_offset=0, sync_session=None, push=True):
 
     last_activity_timestamp = timezone.now() - datetime.timedelta(
         hours=last_activity_offset
@@ -21,13 +21,16 @@ def _create_sessions(last_activity_offset=0, sync_session=None):
             id=uuid.uuid4().hex,
             profile="facilitydata",
             last_activity_timestamp=last_activity_timestamp,
+            client_instance_id=uuid.uuid4().hex,
+            server_instance_id=uuid.uuid4().hex,
         )
 
     transfer_session = TransferSession.objects.create(
         id=uuid.uuid4().hex,
         sync_session=sync_session,
-        push=True,
+        push=push,
         last_activity_timestamp=last_activity_timestamp,
+        filter="1:2\n"
     )
 
     return sync_session, transfer_session
@@ -99,6 +102,43 @@ class CleanupSyncsTestCase(TestCase):
         self.assertSyncSessionIsNotActive(self.syncsession_old)
         self.assertTransferSessionIsNotCleared(self.transfersession_new)
         self.assertSyncSessionIsActive(self.syncsession_new)
+
+    def test_filtering_sessions_by_client_instance_id_cleared(self):
+        call_command("cleanupsyncs", client_instance_id=self.syncsession_old.client_instance_id, expiration=0)
+        self.assertTransferSessionIsCleared(self.transfersession_old)
+        self.assertSyncSessionIsNotActive(self.syncsession_old)
+        self.assertTransferSessionIsNotCleared(self.transfersession_new)
+        self.assertSyncSessionIsActive(self.syncsession_new)
+
+    def test_filtering_sessions_by_server_instance_id_cleared(self):
+        call_command("cleanupsyncs", server_instance_id=self.syncsession_old.server_instance_id, expiration=0)
+        self.assertTransferSessionIsCleared(self.transfersession_old)
+        self.assertSyncSessionIsNotActive(self.syncsession_old)
+        self.assertTransferSessionIsNotCleared(self.transfersession_new)
+        self.assertSyncSessionIsActive(self.syncsession_new)
+
+    def test_filtering_sessions_by_sync_filter_cleared(self):
+        call_command("cleanupsyncs", sync_filter=self.transfersession_old.filter, expiration=0)
+        self.assertTransferSessionIsCleared(self.transfersession_old)
+        self.assertSyncSessionIsNotActive(self.syncsession_old)
+        self.assertTransferSessionIsCleared(self.transfersession_new)
+        self.assertSyncSessionIsNotActive(self.syncsession_new)
+
+    def test_filtering_sessions_by_push_cleared(self):
+        call_command("cleanupsyncs", push=self.transfersession_old.push, expiration=0)
+        self.assertTransferSessionIsCleared(self.transfersession_old)
+        self.assertSyncSessionIsNotActive(self.syncsession_old)
+        self.assertTransferSessionIsCleared(self.transfersession_new)
+        self.assertSyncSessionIsNotActive(self.syncsession_new)
+
+    def test_filtering_sessions_by_pull_cleared(self):
+        syncsession_old, transfersession_old = _create_sessions(push=False)
+        syncsession_new, transfersession_new = _create_sessions(push=False)
+        call_command("cleanupsyncs", pull=not transfersession_old.push, expiration=0)
+        self.assertTransferSessionIsCleared(transfersession_old)
+        self.assertSyncSessionIsActive(syncsession_old)
+        self.assertTransferSessionIsCleared(transfersession_new)
+        self.assertSyncSessionIsActive(syncsession_new)
 
     def test_multiple_ids_as_list(self):
         ids = [self.syncsession_old.id, self.syncsession_new.id]


### PR DESCRIPTION
## Summary

This PR adds parameters for sync filter and instance (server or client) to `cleanupsyncs` parameters added include;
- `sync_filter `
- `client_instance_id `
- `server_instance_id `
- `push` and `pull`

## TODO

- [x] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed
Fixes #184 

List the issues solved or partly solved by the PR

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)
