### PR TITLE
Update publish workflow to allow continued 0.6.x releases

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,11 +14,13 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
-    container:
-      image: python:2.7.18-buster
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,15 +14,11 @@ on:
 
 jobs:
   deploy:
-
-    runs-on: ubuntu-18.04
-
+    runs-on: ubuntu-20.04
+    container:
+      image: python:2.7.18-buster
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 2.7
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- Updates the Github workflow for publishing `morango` to use a python 3.9
