### PR TITLE
Add optional setting to ignore an existing process on resuming a sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ List of the most important changes for each release.
 ## 0.6.17
 - Added `client-instance-id`, `server-instance-id`, `sync-filter`, `push` and `pull` arguments to `cleanupsyncs` management command
 - Added option for resuming a sync to ignore the `SyncSession`'s existing `process_id`
+- Added custom user agent to sync HTTP requests
+- Fixed documentation build issues
+- Makefile no longer defines shell with explicit path
 
 ## 0.6.16
 - Added dedicated `client_instance_id` and `server_instance_id` fields to `SyncSession`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 List of the most important changes for each release.
 ## 0.6.17
 - Added `client-instance-id`, `server-instance-id`, `sync-filter`, `push` and `pull` arguments to `cleanupsyncs` management command
+- Added option for resuming a sync to ignore the `SyncSession`'s existing `process_id`
 
 ## 0.6.16
 - Added dedicated `client_instance_id` and `server_instance_id` fields to `SyncSession`

--- a/morango/sync/syncsession.py
+++ b/morango/sync/syncsession.py
@@ -260,12 +260,16 @@ class NetworkSyncConnection(Connection):
         sync_session = SyncSession.objects.create(**data)
         return SyncSessionClient(self, sync_session)
 
-    def resume_sync_session(self, sync_session_id, chunk_size=None):
+    def resume_sync_session(self, sync_session_id, chunk_size=None, ignore_existing_process=False):
         """
         Resumes an existing sync session given an ID
 
         :param sync_session_id: The UUID of the `SyncSession` to resume
         :param chunk_size: An optional parameter specifying the size for each transferred chunk
+        :type chunk_size: int
+        :param ignore_existing_process:An optional parameter specifying whether to ignore an
+            existing active process ID
+        :type ignore_existing_process: bool
         :return: A SyncSessionClient instance
         :rtype: SyncSessionClient
         """
@@ -281,7 +285,8 @@ class NetworkSyncConnection(Connection):
 
         # check that process of existing session isn't still running
         if (
-            sync_session.process_id
+            not ignore_existing_process
+            and sync_session.process_id
             and sync_session.process_id != os.getpid()
             and pid_exists(sync_session.process_id)
         ):


### PR DESCRIPTION
## Background
Morango stores the process ID on the sync session to prevent accidental resumption of a sync that is still active in another process. On Kolibri, if a sync was started via the UI but then fails, when a user tries to manually resume the sync outside of Kolibri's UI and task processing, the check that ensures the process ID is either the same or inactive can fail because the worker processing tasks is likely still a running and active process.

## Summary
- Adds `ignore_existing_process` keyword arg to `resume_sync_session` allowing the bypass of checking the existing process ID

## TODO

- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance
- The test and code review
- This work has been merged into [this PR](https://github.com/learningequality/morango/pull/188), which will run GH action checks against the updates

## Issues addressed
Fixes https://github.com/learningequality/morango/issues/193

