### PR TITLE
Add custom user agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,8 +77,9 @@ target/
 # celery beat schedule file
 celerybeat-schedule
 
-# dotenv
+# dotenv, envrc
 .env
+.envrc
 
 # virtualenv
 venv/

--- a/morango/sync/session.py
+++ b/morango/sync/session.py
@@ -1,11 +1,13 @@
 import logging
 
 from requests import exceptions
+from morango import __version__
 from requests.sessions import Session
 from requests.utils import super_len
 from requests.packages.urllib3.util.url import parse_url
 
 from morango.utils import serialize_capabilities_to_client_request
+from morango.utils import SETTINGS
 
 
 logger = logging.getLogger(__name__)
@@ -34,6 +36,15 @@ class SessionWrapper(Session):
 
     bytes_sent = 0
     bytes_received = 0
+
+    def __init__(self):
+        super(SessionWrapper, self).__init__()
+        user_agent_header = "morango/{}".format(__version__)
+        if SETTINGS.CUSTOM_INSTANCE_INFO is not None:
+            instances = list(SETTINGS.CUSTOM_INSTANCE_INFO)
+            if instances:
+                user_agent_header += " " + "{}/{}".format(instances[0], SETTINGS.CUSTOM_INSTANCE_INFO.get(instances[0]))
+        self.headers["User-Agent"] = "{} {}".format(user_agent_header, self.headers["User-Agent"])
 
     def request(self, method, url, **kwargs):
         response = None

--- a/tests/testapp/tests/sync/test_session.py
+++ b/tests/testapp/tests/sync/test_session.py
@@ -24,6 +24,19 @@ class SessionWrapperTestCase(TestCase):
         head_length = len("HTTP/1.1 200 OK") + _length_of_headers(headers)
         self.assertEqual(wrapper.bytes_received, 1024 + head_length)
 
+    def test_request_user_agent(self):
+        from morango import __version__ as morango_version
+        from requests import __version__ as requests_version
+
+        wrapper = SessionWrapper()
+        expected_user_agent = "morango/{} python-requests/{}".format(morango_version, requests_version)
+        self.assertEqual(wrapper.headers["User-Agent"], expected_user_agent)
+
+        with self.settings(CUSTOM_INSTANCE_INFO={"kolibri": "0.16.0"}):
+            wrapper = SessionWrapper()
+            expected_user_agent = "morango/{} kolibri/0.16.0 python-requests/{}".format(morango_version, requests_version)
+            self.assertEqual(wrapper.headers["User-Agent"], expected_user_agent)
+
     @mock.patch("morango.sync.session.logger")
     @mock.patch("morango.sync.session.Session.request")
     def test_request__not_ok(self, mocked_super_request, mocked_logger):


### PR DESCRIPTION
## Summary

Supersedes https://github.com/learningequality/morango/pull/196

This PR adds a custom user agent that adds information about morango and the product it is integrated with. 

For example, with Kolibri 0.16.0, user agent should be:-

`User-Agent: morango/0.6.17 kolibri/0.16.0 python-requests/2.28.2 `

## TODO

- [x] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance

The unit test should be sufficient I feel.

## Issues addressed

Closes https://github.com/learningequality/morango/issues/191.
