### PR TITLE
Add the ReadTheDocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+version: 2
+formats: all
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+sphinx:
+  configuration: docs/conf.py
+python:
+  install:
+  - requirements: requirements/docs.txt


### PR DESCRIPTION
## Summary

- Starting on September 25, ReadTheDocs builds without configuration file won't work anymore. This adds the configuration file.
- Enables `sphinx-rtd-theme` for the production build
  - Previously, it was enabled only for local builds, probably because it was applied by default by ReadTheDocs. However, ReadTheDocs is generally moving towards requiring explicit configuration and having the theme disabled for production seems to be the cause of some recent troubles with theme in one of our products.

## References

https://blog.readthedocs.com/migrate-configuration-v2/

## Reviewer guidance

- Preview the configuration file
- Preview the production docs build: TBD
- Preview the local docs build