### PR TITLE
Ensure initialization signals get fired during sync

### DIFF
--- a/morango/api/viewsets.py
+++ b/morango/api/viewsets.py
@@ -383,6 +383,10 @@ class TransferSessionViewSet(
             is_push=is_a_push,
         )
 
+        # Manually fire the initializing started signal, as the default context
+        # stage is initializing, so otherwise this never gets fired.
+        session_controller.signals.initializing.started.fire(context=context)
+
         # If both client and ourselves allow async, we just return accepted status, and the client
         # should PATCH the transfer_session to the appropriate stage. If not async, we wait until
         # queuing is complete

--- a/morango/sync/utils.py
+++ b/morango/sync/utils.py
@@ -181,6 +181,14 @@ class SyncSignal(object):
         """
         self._handlers.append(handler)
 
+    def disconnect(self, handler):
+        """
+        Removes a callable handler that would be called when the signal is fired.
+
+        :type handler: function
+        """
+        self._handlers.remove(handler)
+
     def fire(self, **kwargs):
         """
         Fires the handler functions connected via `connect`.


### PR DESCRIPTION
## Summary
* The default transfer_stage value set for contexts is INIITIALIZING - because of this, the started signals for this stage are never fired, as the middleware processing always flags it as at that stage.
* To resolve this, I've added a manual firing of the initializing started signal when a transfer session object is created
* Adds a test to ensure this is the case.

## TODO

- [X] Have tests been written for the new code?

## Reviewer guidance

I initially attempted a more general approach by creating a NO_STAGE stage to allow the initializing started signal to get triggered, but it broke another test. While it fixed the test here, it did not seem to alter the behaviour in Kolibri. I also didn't know whether this would have implications for the Kolibri sync commands, which seem to explicitly fire the initializing started event: https://github.com/learningequality/kolibri/blob/release-v0.16.x/kolibri/core/auth/management/utils.py#L615

## Issues addressed

This should resolve https://github.com/learningequality/kolibri/issues/10588 by ensuring that when an inbound sync happens, the pre-transfer hooks are properly executed: https://github.com/learningequality/kolibri/blob/release-v0.16.x/kolibri/core/auth/sync_event_hook_utils.py#L130
