### PR TITLE
Update ReadTheDocs builds configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+version: 2
+formats: all
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+sphinx:
+  configuration: docs/conf.py
+python:
+  install:
+  - requirements: requirements/docs.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ formats: all
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.9"
 sphinx:
   configuration: docs/conf.py
 python:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,3 +9,4 @@ sphinx:
 python:
   install:
   - requirements: requirements/docs.txt
+  - path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,8 @@ import django
 from django.utils.encoding import force_text
 from django.utils.html import strip_tags
 
+import sphinx_rtd_theme
+
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory is
 # relative to the documentation root, use os.path.abspath to make it
@@ -164,14 +166,10 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+# html_theme = 'default'
 
-if not False:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [".", sphinx_rtd_theme.get_html_theme_path()]
-
+html_theme = "sphinx_rtd_theme"
+html_theme_path = [".", sphinx_rtd_theme.get_html_theme_path()]
 
 # Approach 2 for custom stylesheet:
 # adapted from: http://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -15,5 +15,3 @@ djangorestframework==3.9.1
 django-mptt==0.9.1
 rsa==3.4.2
 ifcfg==0.21
-
--r ./accelerated.txt


### PR DESCRIPTION
## Summary

- Starting on September 25, ReadTheDocs builds without configuration file won't work anymore. This adds the configuration file.
- Cleans up code around `sphinx-rtd-theme` configuration

## References

https://blog.readthedocs.com/migrate-configuration-v2/

## Reviewer guidance

- Preview the configuration file
- Preview the production docs build: TODO
- Preview the local docs build