### PR TITLE
No deleted model tracking in deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release Notes
 
 List of the most important changes for each release.
+
+## 0.6.18
+- Prevent creation of Deleted and HardDeleted models during deserialization to allow propagation of syncable objects that are recreated after a previous deletion without causing a merge conflict.
+
 ## 0.6.17
 - Added `client-instance-id`, `server-instance-id`, `sync-filter`, `push` and `pull` arguments to `cleanupsyncs` management command
 - Added option for resuming a sync to ignore the `SyncSession`'s existing `process_id`

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.17"
+__version__ = "0.6.18"

--- a/morango/models/core.py
+++ b/morango/models/core.py
@@ -469,18 +469,14 @@ class Store(AbstractStore):
         klass_model = syncable_models.get_model(self.profile, self.model_name)
         # if store model marked as deleted, attempt to delete in app layer
         if self.deleted:
-            # if hard deleted, propagate to related models
-            if self.hard_deleted:
-                try:
-                    klass_model.objects.get(id=self.id).delete(hard_delete=True)
-                except klass_model.DoesNotExist:
-                    pass
-            else:
-                # Import here to avoid circular import, as the utils module
-                # imports core models.
-                from morango.sync.utils import mute_signals
-                with mute_signals(signals.post_delete):
-                    klass_model.objects.filter(id=self.id).delete()
+            # Don't differentiate between deletion and hard deletion here,
+            # as we don't want to add additional tracking for models in either case,
+            # just to actually delete them.
+            # Import here to avoid circular import, as the utils module
+            # imports core models.
+            from morango.sync.utils import mute_signals
+            with mute_signals(signals.post_delete):
+                klass_model.objects.filter(id=self.id).delete()
             return None, deferred_fks
         else:
             # load model into memory

--- a/tests/testapp/tests/sync/test_controller.py
+++ b/tests/testapp/tests/sync/test_controller.py
@@ -18,7 +18,6 @@ from morango.constants import transfer_stages
 from morango.constants import transfer_statuses
 from morango.models.certificates import Filter
 from morango.models.core import DeletedModels
-from morango.models.core import HardDeletedModels
 from morango.models.core import InstanceIDModel
 from morango.models.core import RecordMaxCounter
 from morango.models.core import Store
@@ -287,7 +286,7 @@ class SerializeIntoStoreTestCase(TestCase):
         )
         # make sure hard_deleted propagates to related models even if they are not hard_deleted
         self.mc.deserialize_from_store()
-        self.assertTrue(HardDeletedModels.objects.filter(id=log.id).exists())
+        self.assertFalse(SummaryLog.objects.filter(id=log.id).exists())
 
 
 class RecordMaxCounterUpdatesDuringSerialization(TestCase):


### PR DESCRIPTION
## Summary

* Adds a test to ensure that objects that are created, synced, deleted, synced, and then recreated properly sync
* Creates a fix for this by muting DeletedModel creation during deserialization

## TODO

- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance

This seems to not break any existing tests, either here or in the Kolibri integration tests (including an addition I made to test the issue this is intended to address).

What I don't know is if the DeletedModel creation during deserialization is desirable - one possible additional test would be to add an integration test on Kolibri for deletion on A, update on B, and ensure that deletion persists on C when both are synced to it.

## Issues addressed

This is intended to resolve https://github.com/learningequality/kolibri/issues/11208

