### PR TITLE
Don't close sync session unless also older than cutoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 List of the most important changes for each release.
 
+## 0.6.19
+- The `cleanupsyncs` management command now only cleans up sync sessions if also inactive for `expiration` amount of time
+- Fixes issue accessing index on queryset in `cleanupsyncs` management command
+
 ## 0.6.18
 - Prevent creation of Deleted and HardDeleted models during deserialization to allow propagation of syncable objects that are recreated after a previous deletion without causing a merge conflict.
 

--- a/morango/__init__.py
+++ b/morango/__init__.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 default_app_config = "morango.apps.MorangoConfig"
-__version__ = "0.6.18"
+__version__ = "0.6.19"

--- a/tests/testapp/tests/test_management_commands.py
+++ b/tests/testapp/tests/test_management_commands.py
@@ -164,3 +164,14 @@ class CleanupSyncsTestCase(TestCase):
 
         call_command("cleanupsyncs", expiration=36)
         self.assertSyncSessionIsActive(sync_session)
+
+    def test_sync_session_cleanup_with_active_xfer(self):
+        sync_session, transfer_session = _create_sessions(38)
+        # recent successful transfer session
+        transfer_session.active = False
+        transfer_session.save()
+        # create old incomplete transfer session for same session
+        _, new_transfer_session = _create_sessions(34, sync_session=sync_session)
+
+        call_command("cleanupsyncs", expiration=36)
+        self.assertSyncSessionIsActive(sync_session)

--- a/tests/testapp/tests/test_management_commands.py
+++ b/tests/testapp/tests/test_management_commands.py
@@ -136,9 +136,11 @@ class CleanupSyncsTestCase(TestCase):
         syncsession_new, transfersession_new = _create_sessions(push=False)
         call_command("cleanupsyncs", pull=not transfersession_old.push, expiration=0)
         self.assertTransferSessionIsCleared(transfersession_old)
-        self.assertSyncSessionIsActive(syncsession_old)
+        self.assertSyncSessionIsNotActive(syncsession_old)
         self.assertTransferSessionIsCleared(transfersession_new)
-        self.assertSyncSessionIsActive(syncsession_new)
+        self.assertSyncSessionIsNotActive(syncsession_new)
+        self.assertTransferSessionIsNotCleared(self.transfersession_old)
+        self.assertTransferSessionIsNotCleared(self.transfersession_new)
 
     def test_multiple_ids_as_list(self):
         ids = [self.syncsession_old.id, self.syncsession_new.id]
@@ -147,3 +149,18 @@ class CleanupSyncsTestCase(TestCase):
         self.assertSyncSessionIsNotActive(self.syncsession_old)
         self.assertTransferSessionIsCleared(self.transfersession_new)
         self.assertSyncSessionIsNotActive(self.syncsession_new)
+
+    def test_sync_session_cutoff(self):
+        """
+        Test that sync sessions are not cleared even if they have no active transfer sessions,
+        if they are still within the cutoff window.
+        """
+        sync_session, transfer_session = _create_sessions(34)
+        # recent successful transfer session
+        transfer_session.active = False
+        transfer_session.save()
+        # create old incomplete transfer session for same session
+        _, old_transfer_session = _create_sessions(38, sync_session=sync_session)
+
+        call_command("cleanupsyncs", expiration=36)
+        self.assertSyncSessionIsActive(sync_session)


### PR DESCRIPTION
## Summary
In order to support sync resumption and automated clean up of incomplete transfers for Kolibri's learn-only device syncing, the command needs to also filter the sync sessions to only those that have been inactive for at least the `expiration` amount of time
- Fixes issue in iterating over sync sessions
- Adds `last_activity_timestamp` filter to sync sessions before iterating to clean them up

## TODO

- [X] Have tests been written for the new code?
- [ ] Has documentation been written/updated?
- [ ] New dependencies (if any) added to requirements file

## Reviewer guidance
Do the tests make sense

## Issues addressed
Fixes https://github.com/learningequality/morango/issues/183

## Documentation

If the PR has documentation, link the file here (either .rst in your repo or if built on Read The Docs)
