### PR TITLE
Unpin docs dependencies to fix build issues.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,10 +17,9 @@ import os
 import sys
 
 import django
+import sphinx_rtd_theme
 from django.utils.encoding import force_text
 from django.utils.html import strip_tags
-
-import sphinx_rtd_theme
 
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory is
@@ -171,6 +170,7 @@ pygments_style = 'sphinx'
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [".", sphinx_rtd_theme.get_html_theme_path()]
 
+
 # Approach 2 for custom stylesheet:
 # adapted from: http://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html
 # and https://github.com/altair-viz/altair/pull/418/files
@@ -179,7 +179,7 @@ def setup(app):
     # Register the docstring processor with sphinx
     app.connect("autodoc-process-docstring", process_docstring)
     # Add our custom CSS overrides
-    app.add_stylesheet("theme_overrides.css")
+    app.add_css_file("theme_overrides.css")
 
 
 # Theme options are theme-specific and customize the look and feel of a

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,13 +1,10 @@
-sphinx==2.4.4
-sphinx-intl==2.0.1
-sphinx-rtd-theme==0.5.2
-sphinx-autobuild==0.7.1
-watchdog==0.10.3
-m2r==0.2.1
-mistune<2.0.0
-sphinx-notfound-page==0.6
-# Do this to prevent undefined imports in newer versions of Jinja2
-Jinja2<3.1
+sphinx
+sphinx-intl
+sphinx-rtd-theme
+sphinx-autobuild
+watchdog
+m2r
+sphinx-notfound-page
 
 # for extracting model docs
 django==1.11.29  # pyup: >=1.11,<2


### PR DESCRIPTION
## Summary

Unpin docs dependencies to fix readthedocs error

Approach follows what has been done in ricecooker and kolibri to address the same dependency issues.

## Reviewer guidance

If the readthedocs build passes, this is good to go!

