### PR TITLE
More crypto requires

### DIFF
--- a/requirements/accelerated.txt
+++ b/requirements/accelerated.txt
@@ -1,2 +1,2 @@
-M2Crypto==0.37.1
+M2Crypto==0.41.0
 cryptography==40.0.2

--- a/requirements/postgres.txt
+++ b/requirements/postgres.txt
@@ -1,2 +1,2 @@
+-r accelerated.txt
 psycopg2-binary==2.8.6
-cryptography==3.3.2


### PR DESCRIPTION
## Summary

* Removes the redundant specification of cryptography package
* Upgrades M2Crypto to latest (which is still Python 3.6 compatible)

## TODO

- [X] New dependencies (if any) added to requirements file