### PR TITLE
Update github actions to drop use of ubuntu-20.04 runner.

### DIFF
--- a/.github/workflows/check_migrations_sqlite.yml
+++ b/.github/workflows/check_migrations_sqlite.yml
@@ -1,56 +1,53 @@
 name: Migrations for SQLite versions
-
 on: [push, pull_request]
-
 jobs:
-    pre_job:
-        name: Path match check
-        runs-on: ubuntu-latest
-        # Map a step output to a job output
-        outputs:
-            should_skip: ${{ steps.skip_check.outputs.should_skip }}
-        steps:
-            - id: skip_check
-              uses: fkirc/skip-duplicate-actions@master
-              with:
-                  github_token: ${{ github.token }}
-                  paths: '["morango/migrations/*.py", ".github/workflows/check_migrations_sqlite.yml", "setup.py", "requirements/*.txt"]'
-    migration_test:
-        name: SQLite migration tests
-        needs: pre_job
-        runs-on: ubuntu-20.04
-        steps:
-            - uses: actions/checkout@v4
-            - name: Set up Python 3.7
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              uses: actions/setup-python@v5
-              with:
-                  python-version: 3.7
-            - name: Install build dependencies
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              run: sudo apt install -y build-essential tcl
-            - name: Build SQLite 3.25.3
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              run: |
-                  # Following the instructions from https://til.simonwillison.net/sqlite/ld-preload
-                  # to build SQLite from source, using version 3.25.3
-                  wget https://www.sqlite.org/src/tarball/89e099fb/SQLite-89e099fb.tar.gz
-                  tar -xzvf SQLite-89e099fb.tar.gz
-                  cd SQLite-89e099fb
-                  CPPFLAGS="-DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_RTREE=1" ./configure
-                  make
-                  LD_PRELOAD=.libs/libsqlite3.so python3 -c \
-                  'import sqlite3; assert sqlite3.connect(":memory").execute("select sqlite_version()").fetchone()[0] == "3.25.3"'
-                  # Once we have confirmed that this works, set it for subsequent steps
-                  echo "LD_PRELOAD=$(realpath .libs/libsqlite3.so)" >> $GITHUB_ENV
-            - uses: actions/cache@v4
-              with:
-                path: ~/.cache/pip
-                key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
-                restore-keys: |
-                    ${{ runner.os }}-pip-
-            - name: Install dependencies
-              run: pip install .
-            - name: Run migrations
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              run: python tests/testapp/manage.py migrate
+  pre_job:
+    name: Path match check
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          github_token: ${{ github.token }}
+          paths: '["morango/migrations/*.py", ".github/workflows/check_migrations_sqlite.yml", "setup.py", "requirements/*.txt"]'
+  migration_test:
+    name: SQLite migration tests
+    needs: pre_job
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.7-buster
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build dependencies
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: |
+          apt-get -y -qq update
+          apt-get install -y build-essential tcl
+      - name: Build SQLite 3.25.3
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: |
+          # Following the instructions from https://til.simonwillison.net/sqlite/ld-preload
+          # to build SQLite from source, using version 3.25.3
+          wget https://www.sqlite.org/src/tarball/89e099fb/SQLite-89e099fb.tar.gz
+          tar -xzvf SQLite-89e099fb.tar.gz
+          cd SQLite-89e099fb
+          CPPFLAGS="-DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_RTREE=1" ./configure
+          make
+          LD_PRELOAD=.libs/libsqlite3.so python3 -c \
+          'import sqlite3; assert sqlite3.connect(":memory").execute("select sqlite_version()").fetchone()[0] == "3.25.3"'
+          # Once we have confirmed that this works, set it for subsequent steps
+          echo "LD_PRELOAD=$(realpath .libs/libsqlite3.so)" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: pip install .
+      - name: Run migrations
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: python tests/testapp/manage.py migrate

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,152 +1,203 @@
 name: Python tests
-
 on: [push, pull_request]
-
 jobs:
-    pre_job:
-        name: Path match check
-        runs-on: ubuntu-latest
-        # Map a step output to a job output
-        outputs:
-            should_skip: ${{ steps.skip_check.outputs.should_skip }}
-        steps:
-            - id: skip_check
-              uses: fkirc/skip-duplicate-actions@master
-              with:
-                  github_token: ${{ github.token }}
-                  paths: '["**.py", ".github/workflows/tox.yml", "tox.ini", "requirements/*.txt"]'
-    unit_test:
-        name: Python unit tests
-        needs: pre_job
-        runs-on: ubuntu-20.04
-        strategy:
-            max-parallel: 5
-            matrix:
-                python-version: [ 3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12', '3.13' ]
-
-        steps:
-            - uses: actions/checkout@v4
-            - name: Set up Python ${{ matrix.python-version }}
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              uses: actions/setup-python@v5
-              with:
-                  python-version: ${{ matrix.python-version }}
-            - name: Install tox
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install tox
-            - name: tox env cache
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              uses: actions/cache@v4
-              with:
-                  path: ${{ github.workspace }}/.tox/py${{ matrix.python-version }}
-                  key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-${{ hashFiles('setup.py', 'requirements/*.txt') }}
-            - name: Test with tox
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              run: tox -e py${{ matrix.python-version }}
-    cryptography:
-        name: Python unit tests + cryptography
-        needs: pre_job
-        runs-on: ubuntu-20.04
+  pre_job:
+    name: Path match check
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          github_token: ${{ github.token }}
+          paths: '["**.py", ".github/workflows/tox.yml", "tox.ini", "requirements/*.txt"]'
+  unit_test:
+    name: Python unit tests
+    needs: pre_job
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+      matrix:
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tox
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: tox env cache
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.tox/py${{ matrix.python-version }}
+          key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-${{ hashFiles('setup.py', 'requirements/*.txt') }}
+      - name: Test with tox
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: tox -e py${{ matrix.python-version }}
+  unit_test_eol_python:
+    name: Python unit tests for EOL Python versions
+    needs: pre_job
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    container:
+      image: python:${{ matrix.python-version }}-buster
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install tox
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: tox env cache
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.tox/py${{ matrix.python-version }}
+          key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-${{ hashFiles('setup.py', 'requirements/*.txt') }}
+      - name: Test with tox
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: tox -e py${{ matrix.python-version }}
+  cryptography:
+    name: Python unit tests + cryptography
+    needs: pre_job
+    runs-on: ubuntu-latest
+    env:
+      cryptography_version: '40.0.2'
+    strategy:
+      max-parallel: 5
+      matrix:
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install system dependencies
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: |
+          sudo apt-get -y -qq update
+          sudo apt-get install -y openssl libssl-dev
+      - name: Install tox
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: tox env cache
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.tox/py${{ matrix.python-version }}-cryptography${{ env.cryptography_version }}
+          key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-crypto${{ env.cryptography_version }}-${{ hashFiles('setup.py', 'requirements/*.txt') }}
+      - name: Test with tox
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: tox -e py${{ matrix.python-version }}-cryptography${{ env.cryptography_version }}
+  cryptography_eol_python:
+    name: Python unit tests + cryptography for EOL Python versions
+    needs: pre_job
+    runs-on: ubuntu-latest
+    env:
+      cryptography_version: '40.0.2'
+    strategy:
+      max-parallel: 5
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    container:
+      image: python:${{ matrix.python-version }}-buster
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install system dependencies
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: |
+          apt-get -y -qq update
+          apt-get install -y openssl libssl-dev
+      - name: Install tox
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: tox env cache
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.tox/py${{ matrix.python-version }}-cryptography${{ env.cryptography_version }}
+          key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-crypto${{ env.cryptography_version }}-${{ hashFiles('setup.py', 'requirements/*.txt') }}
+      - name: Test with tox
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: tox -e py${{ matrix.python-version }}-cryptography${{ env.cryptography_version }}
+  postgres:
+    name: Python postgres unit tests
+    needs: pre_job
+    runs-on: ubuntu-latest
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
         env:
-            cryptography_version: '40.0.2'
-        strategy:
-            max-parallel: 5
-            matrix:
-                python-version: [ 3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12', '3.13' ]
-
-        steps:
-            - uses: actions/checkout@v4
-            - name: Set up Python ${{ matrix.python-version }}
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              uses: actions/setup-python@v5
-              with:
-                  python-version: ${{ matrix.python-version }}
-            - name: Install system dependencies
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              run: |
-                sudo apt-get -y -qq update
-                sudo apt-get install -y openssl libssl-dev
-            - name: Install tox
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              run: |
-                python -m pip install --upgrade pip
-                pip install tox
-            - name: tox env cache
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              uses: actions/cache@v4
-              with:
-                  path: ${{ github.workspace }}/.tox/py${{ matrix.python-version }}-cryptography${{ env.cryptography_version }}
-                  key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-crypto${{ env.cryptography_version }}-${{ hashFiles('setup.py', 'requirements/*.txt') }}
-            - name: Test with tox
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              run: tox -e py${{ matrix.python-version }}-cryptography${{ env.cryptography_version }}
-    postgres:
-        name: Python postgres unit tests
-        needs: pre_job
-        runs-on: ubuntu-20.04
-        services:
-            # Label used to access the service container
-            postgres:
-                # Docker Hub image
-                image: postgres
-                # Provide the password for postgres
-                env:
-                    POSTGRES_USER: postgres
-                    POSTGRES_PASSWORD: postgres
-                    POSTGRES_DB: test
-                # Set health checks to wait until postgres has started
-                options: >-
-                    --health-cmd pg_isready
-                    --health-interval 10s
-                    --health-timeout 5s
-                    --health-retries 5
-                ports:
-                    # Maps tcp port 5432 on service container to the host
-                    - 5432:5432
-        steps:
-            - uses: actions/checkout@v4
-            - name: Set up Python 3.9 for Postgres
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              uses: actions/setup-python@v5
-              with:
-                  python-version: 3.9
-            - name: Install tox
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install tox
-            - name: tox env cache
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              uses: actions/cache@v4
-              with:
-                  path: ${{ github.workspace }}/.tox/py3.9-postgres
-                  key: ${{ runner.os }}-tox-py3.9-postgres-${{ hashFiles('setup.py', 'requirements/*.txt') }}
-            - name: Test with tox
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              run: tox -e postgres
-    windows:
-        name: Python unit tests on Windows Server
-        needs: pre_job
-        runs-on: windows-latest
-        strategy:
-            max-parallel: 5
-            matrix:
-                python-version: [3.8]
-
-        steps:
-            - uses: actions/checkout@v4
-            - name: Set up Python ${{ matrix.python-version }}
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              uses: actions/setup-python@v5
-              with:
-                  python-version: ${{ matrix.python-version }}
-            - name: Install tox
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install tox
-            - name: Test with tox
-              if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-              run: tox -e windows
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.9 for Postgres
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      - name: Install tox
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: tox env cache
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.tox/py3.9-postgres
+          key: ${{ runner.os }}-tox-py3.9-postgres-${{ hashFiles('setup.py', 'requirements/*.txt') }}
+      - name: Test with tox
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: tox -e postgres
+  windows:
+    name: Python unit tests on Windows Server
+    needs: pre_job
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 5
+      matrix:
+        python-version: [3.8]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tox
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Test with tox
+        if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+        run: tox -e windows

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,24 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:
-    -   id: trailing-whitespace
-    -   id: flake8
-    -   id: check-yaml
-    -   id: check-added-large-files
-    -   id: debug-statements
-    -   id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: flake8
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: debug-statements
+      - id: end-of-file-fixer
         exclude: '^.+?\.json$'
--   repo: https://github.com/asottile/reorder_python_imports
+  - repo: https://github.com/asottile/reorder_python_imports
     rev: v1.4.0
     hooks:
-    -   id: reorder-python-imports
+      - id: reorder-python-imports
         language_version: python3
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.14.0
+    hooks:
+      - id: yamlfmt
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 
 lint:
-	flake8 morango
+	pre-commit run --all-files
 
 migrations:
 	python tests/testapp/manage.py makemigrations

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,2 @@
-flake8==2.6.0
-pre-commit==1.15.1
+pre-commit==4.1.0
 tox==3.14.6

--- a/tests/testapp/tests/compat.py
+++ b/tests/testapp/tests/compat.py
@@ -1,6 +1,11 @@
 try:
-    # For python >2.7 and <3.10
-    from test.support import EnvironmentVarGuard # noqa F401
+    # In the Python EOL GH workflows, we have to install backported version
+    # as the Docker container images we use does not have the test module installed.
+    from backports.test.support import EnvironmentVarGuard # noqa F401
 except ImportError:
-    # In Python 3.10, this has been moved to test.support.os_helper
-    from test.support.os_helper import EnvironmentVarGuard # noqa F401
+    try:
+        # For python >3.8 and <3.10
+        from test.support import EnvironmentVarGuard # noqa F401
+    except ImportError:
+        # In Python 3.10, this has been moved to test.support.os_helper
+        from test.support.os_helper import EnvironmentVarGuard # noqa F401

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,9 @@ basepython =
 deps =
   -r{toxinidir}/requirements/test.txt
   cryptography40.0.2: cryptography==40.0.2
+  py3.6: backports.test.support==0.1.1
+  py3.7: backports.test.support==0.1.1
+  py3.8: backports.test.support==0.1.1
 commands =
   sh -c 'tests/testapp/manage.py makemigrations --check'
   python -O -m pytest {posargs: --color=no}


### PR DESCRIPTION
## Summary
* Test all EOL Python versions in a docker container.
* Add pre-commit hooks for yaml file formatting and github action linting.
* Remove use of flake8 outside of pre-commit hook
* Update pre-commit to latest version

## TODO

- [X] New dependencies (if any) added to requirements file

## Reviewer guidance

This should future proof our Github actions tests, but does change the name of some actions, so required checks will be mismatched until we update them.

## Issues addressed

Fixes morango portion of https://github.com/learningequality/kolibri-ecosystem/issues/41
