### PR TITLE
Fix github actions runner failures due to debian buster packages only being available on archive.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/SQLite-89e099fb.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/check_migrations_sqlite.yml
+++ b/.github/workflows/check_migrations_sqlite.yml
@@ -20,7 +20,6 @@ jobs:
     container:
       image: python:3.7-buster
     steps:
-      - uses: actions/checkout@v4
       - name: Install build dependencies
         if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
         run: |
@@ -28,14 +27,16 @@ jobs:
           echo "deb http://archive.debian.org/debian-archive/debian-security/ buster/updates main" >> /etc/apt/sources.list
           echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99archive
           apt-get -y -qq update
-          apt-get install -y build-essential tcl
+          apt-get install -y build-essential tcl git-lfs
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Build SQLite 3.25.3
         if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
         run: |
           # Following the instructions from https://til.simonwillison.net/sqlite/ld-preload
           # to build SQLite from source, using version 3.25.3
-          wget https://www.sqlite.org/src/tarball/89e099fb/SQLite-89e099fb.tar.gz
-          tar -xzvf SQLite-89e099fb.tar.gz
+          tar -xzvf tests/SQLite-89e099fb.tar.gz
           cd SQLite-89e099fb
           CPPFLAGS="-DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_RTREE=1" ./configure
           make

--- a/.github/workflows/check_migrations_sqlite.yml
+++ b/.github/workflows/check_migrations_sqlite.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install build dependencies
         if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
         run: |
+          echo "deb http://archive.debian.org/debian-archive/debian/ buster main" > /etc/apt/sources.list
+          echo "deb http://archive.debian.org/debian-archive/debian-security/ buster/updates main" >> /etc/apt/sources.list
+          echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99archive
           apt-get -y -qq update
           apt-get install -y build-essential tcl
       - name: Build SQLite 3.25.3

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -121,6 +121,9 @@ jobs:
       - name: Install system dependencies
         if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
         run: |
+          echo "deb http://archive.debian.org/debian-archive/debian/ buster main" > /etc/apt/sources.list
+          echo "deb http://archive.debian.org/debian-archive/debian-security/ buster/updates main" >> /etc/apt/sources.list
+          echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99archive
           apt-get -y -qq update
           apt-get install -y openssl libssl-dev
       - name: Install tox

--- a/tests/SQLite-89e099fb.tar.gz
+++ b/tests/SQLite-89e099fb.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:645b0ae19827ad5aeba6a324f110b7a54a2d1c4a083d231f24618a2a64a201df
+size 10004433


### PR DESCRIPTION
## Summary
Should fix build failures on PRs

Copies solution implemented in Kolibri for the same error: https://github.com/learningequality/kolibri/pull/13553