### PR TITLE
Include uv.lock in path match check, to ensure we're not breaking CI

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -12,7 +12,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           github_token: ${{ github.token }}
-          paths: '["docs/**", "pyproject.toml"]'
+          paths: '["docs/**", "pyproject.toml", "uv.lock"]'
   docs:
     name: Checking docs build
     needs: pre_job

--- a/.github/workflows/check_migrations_sqlite.yml
+++ b/.github/workflows/check_migrations_sqlite.yml
@@ -12,7 +12,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           github_token: ${{ github.token }}
-          paths: '["morango/migrations/*.py", ".github/workflows/check_migrations_sqlite.yml", "pyproject.toml"]'
+          paths: '["morango/migrations/*.py", ".github/workflows/check_migrations_sqlite.yml", "pyproject.toml", "uv.lock"]'
   build:
     name: Build wheel
     needs: pre_job

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -12,7 +12,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           github_token: ${{ github.token }}
-          paths: '["**.py", ".github/workflows/tox.yml", "tox.ini", "pyproject.toml"]'
+          paths: '["**.py", ".github/workflows/tox.yml", "tox.ini", "pyproject.toml", "uv.lock"]'
   build:
     name: Build wheel
     needs: pre_job


### PR DESCRIPTION
## Summary
I missed adding `uv.lock` to the 'Path match check' which is used to skip things when unnecessary. This ensures we're running CI when dependencies change. Since `pyproject.toml` was already there, this covers the case where a dep of a dep gets updated by dependabot (like https://github.com/learningequality/morango/pull/300) which ends up only updating the `uv.lock` file.
