### PR TITLE
Fixes dependabot config and ignores formatting 

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Run this command to always ignore formatting commits in `git blame`
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Linting updates and fixes
+292f58e2d60c1721349b1a0bb1bbbebf4809481e

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       day: "friday"
       time: "00:00"
     cooldown:
-      days: 7
+      default-days: 7
   # Maintain dependencies for Github Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -23,4 +23,4 @@ updates:
         patterns:
           - "actions/*"
     cooldown:
-      days: 7
+      default-days: 7


### PR DESCRIPTION
## Summary
Followup to https://github.com/learningequality/morango/pull/312

I didn't notice the dependabot config was incorrect, so this fixes it. I also added a `.git-blame-ignore-revs` to ignore its formatting commit.
