### PR TITLE
Remove multiprocessing fallback for key generation. Stay in process.

### DIFF
--- a/morango/models/fields/crypto.py
+++ b/morango/models/fields/crypto.py
@@ -189,10 +189,7 @@ class PythonRSAKey(BaseKey):
     _private_key = None
 
     def generate_new_key(self, keysize=2048):
-        try:
-            self._public_key, self._private_key = PYRSA.newkeys(keysize, poolsize=4)
-        except:  # noqa: E722
-            self._public_key, self._private_key = PYRSA.newkeys(keysize)
+        self._public_key, self._private_key = PYRSA.newkeys(keysize)
 
     def _sign(self, message):
 


### PR DESCRIPTION
## Summary

Removes the multiprocessing usage when creating keys using pure Python RSA - when no cryptography library is installed.

## Reviewer guidance

I don't think this loses any error handling as we were calling this code in the `except` clause before anyway.

## Issues addressed

No explicit issues, may clean up zombies on no cextension Kolibris though.